### PR TITLE
#113 into release@3.3.0 👹 fix graphql types and validation

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -20,6 +20,7 @@
     }
   },
   "rules": {
+    "quotes": ["error", "single"],
     "consistent-return": "off",
     "no-shadow": "off",
     "no-restricted-syntax": "off",

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -6,7 +6,7 @@ then
     branch=$(git symbolic-ref --short HEAD)
     emoji=$(cat .emoji)
     message=$(cat "$1")
-    if echo "$message" | (! grep -q "^${branch} ${emoji}*")
+    if echo "$message" | (! grep -q "^${branch} ${emoji}*") && echo "$message" | (! grep -q "^Merge branch*")
     then
         echo "$branch $emoji $(cat $1)" > "$1"
     fi

--- a/README.md
+++ b/README.md
@@ -229,8 +229,6 @@ Allowed `checkModes`
 
 Value for `checkMode` except `function` | `exists` | `notExists` can be array, so you can write even more complex logic. For example "does not contain these values" or "must be match to one of these regExp".
 
-> If `checkMode` doesn't defined then `checkMode=equals` is used
-
 ```javascript
 /** @type {import('mock-config-server').MockServerConfig} */
 const mockServerConfig = {

--- a/README.md
+++ b/README.md
@@ -229,6 +229,8 @@ Allowed `checkModes`
 
 Value for `checkMode` except `function` | `exists` | `notExists` can be array, so you can write even more complex logic. For example "does not contain these values" or "must be match to one of these regExp".
 
+> If `checkMode` doesn't defined then `checkMode=equals` is used
+
 ```javascript
 /** @type {import('mock-config-server').MockServerConfig} */
 const mockServerConfig = {
@@ -263,6 +265,35 @@ const mockServerConfig = {
               }
             },
             data: 'Some user data for Dmitriy and Nursultan'
+          }
+        ]
+      }
+    ]
+  }
+};
+
+module.exports = mockServerConfig;
+```
+
+Also you can use array as value for REST body and GraphQL variables entities: in this case mock-config-server will iterate
+over array until `checkMode=equals` finds a match or return 404
+
+```javascript
+/** @type {import('mock-config-server').MockServerConfig} */
+const mockServerConfig = {
+  rest: {
+    baseUrl: '/api',
+    configs: [
+      {
+        path: '/user',
+        method: 'post',
+        routes: [
+          {
+            entities: {
+              // if body equals to { key1: 'value1' } or ['value1'] then mock-config-server return data
+              body: [{ key1: 'value1' }, ['value1']]
+            },
+            data: 'Some user data'
           }
         ]
       }

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ export default mockServerConfig;
 Start **🎉 Mock Config Server**
 
 ```bash
-npx mock-config-server
+$ npx mock-config-server
 ```
 
 > If the package is already installed you can use short command `mcs`

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ export default mockServerConfig;
 Start **🎉 Mock Config Server**
 
 ```bash
-$ npx mock-config-server
+npx mock-config-server
 ```
 
 > If the package is already installed you can use short command `mcs`
@@ -73,7 +73,7 @@ $ npx mock-config-server
   - `baseUrl?` {string} part of the url that will be substituted at the beginning of graphql request url (default: `'/'`)
   - `configs` {Array<GraphQLRequestConfig>} configs for mock requests, [read](#configs)
   - `interceptors?` {Interceptors} functions to change request or response parameters, [read](#interceptors)
-- `database?` Database config for mock requests [read](#Database)
+- `database?` Database config for mock requests [read](#database)
   - `data` {Object | string} initial data for database
   - `routes?` {Object | string} map of custom routes for database
 - `staticPath?` {StaticPath} entity for working with static files, [read](#static-path)
@@ -99,12 +99,15 @@ Configs are the fundamental part of the mock server. These configs are easy to f
 ##### GraphQL request config
 
 - `operationType` {query | mutation} graphql operation type
-- `operationName` {string} graphql operation name
+- `operationName?` {string | RegExp} graphql operation name
+- `query?`: {string} graphql query as string
 - `routes` {GraphQLRouteConfig[]} request routes
   - `data` {any} mock data of request
   - `entities?` Object<headers | cookies | query | variables> object that helps in data retrieval
   - `interceptors?` {Interceptors} functions to change request or response parameters, [read](#interceptors)
 - `interceptors?` {Interceptors} functions to change request or response parameters, [read](#interceptors)
+
+> Every graphql config should contain `operationName` or `query` or both of them
 
 ##### Rest example
 
@@ -210,6 +213,7 @@ If you need more complex logic for matching entities, you can use entity descrip
 Descriptor is an object with `checkMode` and `value` fields that describe how the correctness of the actual entity is calculated.
 
 Allowed `checkModes`
+
 - equals - checks actual value for equality with descriptor value (default).
 - notEquals - checks actual value for non-equality with descriptor value.
 - exists - checks actual value for existence i.e. any value.
@@ -264,7 +268,7 @@ const mockServerConfig = {
       }
     ]
   }
-}
+};
 
 module.exports = mockServerConfig;
 ```
@@ -309,7 +313,7 @@ const mockServerConfig = {
           {
             entities: {
               body: {
-                'title': {
+                title: {
                   checkMode: 'startsWith',
                   value: 'A'
                 }
@@ -329,7 +333,7 @@ const mockServerConfig = {
                 {
                   checkMode: 'startsWith',
                   value: 1
-                }, 
+                },
                 2
               ]
             },
@@ -339,7 +343,7 @@ const mockServerConfig = {
       }
     ]
   }
-}
+};
 
 module.exports = mockServerConfig;
 ```
@@ -375,7 +379,7 @@ const mockServerConfig = {
       }
     ]
   }
-}
+};
 
 module.exports = mockServerConfig;
 ```
@@ -454,6 +458,7 @@ Functions to change request or response parameters
 ## Database
 
 With `mock-config-server` you can create your own mock database with all CRUD operations
+
 - `data` {Object | string} initial data for database
 - `routes?` {Object | string} map of custom routes for database
 
@@ -463,9 +468,7 @@ With `mock-config-server` you can create your own mock database with all CRUD op
 const mockServerConfig = {
   database: {
     data: {
-      users: [
-        { id: 1, name: 'John' }
-      ],
+      users: [{ id: 1, name: 'John' }],
       settings: {
         blocked: false
       }
@@ -477,6 +480,7 @@ const mockServerConfig = {
 Now you have the following routes for requests
 
 #### Collection routes
+
 ```
 GET    /users
 POST   /users
@@ -510,9 +514,7 @@ __routes -> return routes from database config
 const mockServerConfig = {
   database: {
     data: {
-      users: [
-        { id: 1, name: 'John' }
-      ],
+      users: [{ id: 1, name: 'John' }],
       settings: {
         blocked: false
       }
@@ -533,6 +535,7 @@ Now following routes will work correctly
 ```
 
 Note some things:
+
 - String routes should start with forward slash
 - If you want to use id param in route then use only `:id` template
 - You can use `wildcard` only for custom route, **not for real route**
@@ -591,7 +594,7 @@ Examples:
             <br />
             <sub style="font-size:13px"><b>👹 MiaInturi</b></sub>
         </a>
-    </td> 
+    </td>
       <td align="center" style="word-wrap: break-word; width: 100.0; height: 100.0">
         <a href="https://github.com/RiceWithMeat">
             <img src="https://avatars.githubusercontent.com/u/47690223?v=4"

--- a/bin/validateMockServerConfig/helpers/isDescriptorValueValid/isDescriptorValueValid.test.ts
+++ b/bin/validateMockServerConfig/helpers/isDescriptorValueValid/isDescriptorValueValid.test.ts
@@ -1,67 +1,65 @@
 import {
   CHECK_ACTUAL_VALUE_CHECK_MODES,
-  COMPARE_WITH_DESCRIPTOR_VALUE_CHECK_MODES
+  COMPARE_WITH_DESCRIPTOR_ANY_VALUE_CHECK_MODES,
+  COMPARE_WITH_DESCRIPTOR_STRING_VALUE_CHECK_MODES
 } from '@/utils/constants';
 
 import { isDescriptorValueValid } from './isDescriptorValueValid';
 
 describe('isDescriptorValueValid', () => {
-  test('Should throw error if invalid checkMode passed', () => {
-    expect(() => isDescriptorValueValid('wrongCheckMode', 'string')).toThrow(
-      Error('Invalid checkMode')
-    );
-  });
-
   describe('checkActualValue checkModes', () => {
-    test('Should correctly validate descriptor value for ', () => {
+    test('Should correctly validate descriptor value', () => {
       const validDescriptorValue = undefined;
       const invalidDescriptorValues = [true, 1, 'string', null, {}, [], () => {}, /\d/];
 
       CHECK_ACTUAL_VALUE_CHECK_MODES.forEach((checkActualValueCheckMode) => {
-        expect(isDescriptorValueValid(checkActualValueCheckMode, validDescriptorValue)).toBe(true);
-
-        invalidDescriptorValues.forEach((invalidDescriptorValue) => {
-          expect(isDescriptorValueValid(checkActualValueCheckMode, invalidDescriptorValue)).toBe(
-            false
-          );
-        });
-      });
-    });
-  });
-
-  describe('compareWithDescriptorValue checkModes', () => {
-    test('Should correctly validate descriptor value for mapped entity', () => {
-      const validDescriptorValues = [true, 1, 'string'];
-      const invalidDescriptorValues = [null, undefined, {}, [], () => {}, /\d/];
-
-      COMPARE_WITH_DESCRIPTOR_VALUE_CHECK_MODES.forEach((compareWithDescriptorValueCheckMode) => {
-        validDescriptorValues.forEach((validDescriptorValue) => {
-          expect(
-            isDescriptorValueValid(compareWithDescriptorValueCheckMode, validDescriptorValue)
-          ).toBe(true);
-        });
+        expect(isDescriptorValueValid(checkActualValueCheckMode, validDescriptorValue, false)).toBe(
+          true
+        );
 
         invalidDescriptorValues.forEach((invalidDescriptorValue) => {
           expect(
-            isDescriptorValueValid(compareWithDescriptorValueCheckMode, invalidDescriptorValue)
+            isDescriptorValueValid(checkActualValueCheckMode, invalidDescriptorValue, false)
           ).toBe(false);
         });
       });
     });
 
-    test('Should correctly validate descriptor value for plain entity', () => {
-      const validDescriptorValues = [{}, []];
-      const invalidDescriptorValues = [true, 1, 'string', null, undefined, () => {}, /\d/];
-      const plainEntityNames = ['body', 'variables'];
+    test('Should be independent of isCheckAsObject argument', () => {
+      const validDescriptorValue = undefined;
+      const invalidDescriptorValue = true;
 
-      plainEntityNames.forEach((plainEntityName) => {
-        COMPARE_WITH_DESCRIPTOR_VALUE_CHECK_MODES.forEach((compareWithDescriptorValueCheckMode) => {
+      CHECK_ACTUAL_VALUE_CHECK_MODES.forEach((checkActualValueCheckMode) => {
+        expect(isDescriptorValueValid(checkActualValueCheckMode, validDescriptorValue, false)).toBe(
+          true
+        );
+        expect(isDescriptorValueValid(checkActualValueCheckMode, validDescriptorValue, true)).toBe(
+          true
+        );
+
+        expect(
+          isDescriptorValueValid(checkActualValueCheckMode, invalidDescriptorValue, false)
+        ).toBe(false);
+        expect(isDescriptorValueValid(checkActualValueCheckMode, validDescriptorValue, true)).toBe(
+          true
+        );
+      });
+    });
+  });
+
+  describe('compareWithDescriptorAnyValue checkModes', () => {
+    test('Should correctly validate descriptor value for mapped entity', () => {
+      const validDescriptorValues = [true, 1, 'string', null];
+      const invalidDescriptorValues = [undefined, {}, [], () => {}, /\d/];
+
+      COMPARE_WITH_DESCRIPTOR_ANY_VALUE_CHECK_MODES.forEach(
+        (compareWithDescriptorValueCheckMode) => {
           validDescriptorValues.forEach((validDescriptorValue) => {
             expect(
               isDescriptorValueValid(
                 compareWithDescriptorValueCheckMode,
                 validDescriptorValue,
-                plainEntityName
+                false
               )
             ).toBe(true);
           });
@@ -71,12 +69,184 @@ describe('isDescriptorValueValid', () => {
               isDescriptorValueValid(
                 compareWithDescriptorValueCheckMode,
                 invalidDescriptorValue,
-                plainEntityName
+                false
               )
             ).toBe(false);
           });
-        });
-      });
+        }
+      );
+    });
+
+    test('Should correctly validate top level descriptor flatten value for plain entity', () => {
+      const validDescriptorValues = [{}, []];
+      const invalidDescriptorValues = [true, 1, 'string', null, undefined, () => {}, /\d/];
+
+      COMPARE_WITH_DESCRIPTOR_ANY_VALUE_CHECK_MODES.forEach(
+        (compareWithDescriptorValueCheckMode) => {
+          validDescriptorValues.forEach((validDescriptorValue) => {
+            expect(
+              isDescriptorValueValid(
+                compareWithDescriptorValueCheckMode,
+                validDescriptorValue,
+                true
+              )
+            ).toBe(true);
+          });
+
+          invalidDescriptorValues.forEach((invalidDescriptorValue) => {
+            expect(
+              isDescriptorValueValid(
+                compareWithDescriptorValueCheckMode,
+                invalidDescriptorValue,
+                true
+              )
+            ).toBe(false);
+          });
+        }
+      );
+    });
+
+    test('Should correctly validate property level descriptor flatten value for plain entity', () => {
+      const validDescriptorValues = [true, 1, 'string', null];
+      const invalidDescriptorValues = [{}, [], undefined, () => {}, /\d/];
+
+      COMPARE_WITH_DESCRIPTOR_ANY_VALUE_CHECK_MODES.forEach(
+        (compareWithDescriptorValueCheckMode) => {
+          validDescriptorValues.forEach((validDescriptorValue) => {
+            expect(
+              isDescriptorValueValid(
+                compareWithDescriptorValueCheckMode,
+                validDescriptorValue,
+                false
+              )
+            ).toBe(true);
+          });
+
+          invalidDescriptorValues.forEach((invalidDescriptorValue) => {
+            expect(
+              isDescriptorValueValid(
+                compareWithDescriptorValueCheckMode,
+                invalidDescriptorValue,
+                false
+              )
+            ).toBe(false);
+          });
+        }
+      );
+    });
+
+    test('Should correctly validate descriptor nested value for plain entity', () => {
+      const validNestedDescriptorValues = [true, 1, 'string', null, {}, []];
+      const invalidNestedDescriptorValues = [undefined, () => {}, /\d/];
+
+      COMPARE_WITH_DESCRIPTOR_ANY_VALUE_CHECK_MODES.forEach(
+        (compareWithDescriptorValueCheckMode) => {
+          validNestedDescriptorValues.forEach((validNestedDescriptorValue) => {
+            expect(
+              isDescriptorValueValid(
+                compareWithDescriptorValueCheckMode,
+                { key: validNestedDescriptorValue },
+                true
+              )
+            ).toBe(true);
+            expect(
+              isDescriptorValueValid(
+                compareWithDescriptorValueCheckMode,
+                [validNestedDescriptorValue],
+                true
+              )
+            ).toBe(true);
+          });
+
+          invalidNestedDescriptorValues.forEach((invalidNestedDescriptorValue) => {
+            expect(
+              isDescriptorValueValid(
+                compareWithDescriptorValueCheckMode,
+                { key: invalidNestedDescriptorValue },
+                true
+              )
+            ).toBe(false);
+
+            expect(
+              isDescriptorValueValid(
+                compareWithDescriptorValueCheckMode,
+                [invalidNestedDescriptorValue],
+                true
+              )
+            ).toBe(false);
+          });
+        }
+      );
+    });
+  });
+
+  describe('compareWithDescriptorStringValue checkModes', () => {
+    test('Should correctly validate descriptor value', () => {
+      const validDescriptorValues = [true, 1, 'string'];
+      const invalidDescriptorValues = [null, undefined, {}, [], () => {}, /\d/];
+
+      COMPARE_WITH_DESCRIPTOR_STRING_VALUE_CHECK_MODES.forEach(
+        (compareWithDescriptorStringValueCheckMode) => {
+          validDescriptorValues.forEach((validDescriptorValue) => {
+            expect(
+              isDescriptorValueValid(
+                compareWithDescriptorStringValueCheckMode,
+                validDescriptorValue,
+                false
+              )
+            ).toBe(true);
+          });
+
+          invalidDescriptorValues.forEach((invalidDescriptorValue) => {
+            expect(
+              isDescriptorValueValid(
+                compareWithDescriptorStringValueCheckMode,
+                invalidDescriptorValue,
+                false
+              )
+            ).toBe(false);
+          });
+        }
+      );
+    });
+
+    test('Should be independent of isCheckAsObject argument', () => {
+      const validDescriptorValue = 'string';
+      const invalidDescriptorValue = null;
+
+      COMPARE_WITH_DESCRIPTOR_STRING_VALUE_CHECK_MODES.forEach(
+        (compareWithDescriptorStringValueCheckMode) => {
+          expect(
+            isDescriptorValueValid(
+              compareWithDescriptorStringValueCheckMode,
+              validDescriptorValue,
+              false
+            )
+          ).toBe(true);
+          expect(
+            isDescriptorValueValid(
+              compareWithDescriptorStringValueCheckMode,
+              validDescriptorValue,
+              true
+            )
+          ).toBe(true);
+
+          expect(
+            isDescriptorValueValid(
+              compareWithDescriptorStringValueCheckMode,
+              invalidDescriptorValue,
+              false
+            )
+          ).toBe(false);
+          expect(
+            isDescriptorValueValid(
+              compareWithDescriptorStringValueCheckMode,
+              invalidDescriptorValue,
+              true
+            )
+          ).toBe(false);
+        }
+      );
     });
   });
 
@@ -85,11 +255,22 @@ describe('isDescriptorValueValid', () => {
       const validDescriptorValue = () => {};
       const invalidDescriptorValues = [true, 1, 'string', null, undefined, {}, [], /\d/];
 
-      expect(isDescriptorValueValid('function', validDescriptorValue)).toBe(true);
+      expect(isDescriptorValueValid('function', validDescriptorValue, false)).toBe(true);
 
       invalidDescriptorValues.forEach((invalidDescriptorValue) => {
-        expect(isDescriptorValueValid('function', invalidDescriptorValue)).toBe(false);
+        expect(isDescriptorValueValid('function', invalidDescriptorValue, false)).toBe(false);
       });
+    });
+
+    test('Should be independent of isCheckAsObject argument', () => {
+      const validDescriptorValue = () => {};
+      const invalidDescriptorValue = true;
+
+      expect(isDescriptorValueValid('function', validDescriptorValue, false)).toBe(true);
+      expect(isDescriptorValueValid('function', validDescriptorValue, true)).toBe(true);
+
+      expect(isDescriptorValueValid('function', invalidDescriptorValue, false)).toBe(false);
+      expect(isDescriptorValueValid('function', invalidDescriptorValue, true)).toBe(false);
     });
   });
 
@@ -98,11 +279,22 @@ describe('isDescriptorValueValid', () => {
       const validDescriptorValue = /\d/;
       const invalidDescriptorValues = [true, 1, 'string', null, undefined, {}, [], () => {}];
 
-      expect(isDescriptorValueValid('regExp', validDescriptorValue)).toBe(true);
+      expect(isDescriptorValueValid('regExp', validDescriptorValue, false)).toBe(true);
 
       invalidDescriptorValues.forEach((invalidDescriptorValue) => {
-        expect(isDescriptorValueValid('regExp', invalidDescriptorValue)).toBe(false);
+        expect(isDescriptorValueValid('regExp', invalidDescriptorValue, false)).toBe(false);
       });
+    });
+
+    test('Should be independent of isCheckAsObject argument', () => {
+      const validDescriptorValue = /\d/;
+      const invalidDescriptorValue = true;
+
+      expect(isDescriptorValueValid('regExp', validDescriptorValue, false)).toBe(true);
+      expect(isDescriptorValueValid('regExp', validDescriptorValue, true)).toBe(true);
+
+      expect(isDescriptorValueValid('regExp', invalidDescriptorValue, false)).toBe(false);
+      expect(isDescriptorValueValid('regExp', invalidDescriptorValue, true)).toBe(false);
     });
   });
 });

--- a/bin/validateMockServerConfig/helpers/isDescriptorValueValid/isDescriptorValueValid.test.ts
+++ b/bin/validateMockServerConfig/helpers/isDescriptorValueValid/isDescriptorValueValid.test.ts
@@ -13,129 +13,40 @@ describe('isDescriptorValueValid', () => {
       const invalidDescriptorValues = [true, 1, 'string', null, {}, [], () => {}, /\d/];
 
       CHECK_ACTUAL_VALUE_CHECK_MODES.forEach((checkActualValueCheckMode) => {
-        expect(isDescriptorValueValid(checkActualValueCheckMode, validDescriptorValue, false)).toBe(
-          true
-        );
+        expect(isDescriptorValueValid(checkActualValueCheckMode, validDescriptorValue)).toBe(true);
 
         invalidDescriptorValues.forEach((invalidDescriptorValue) => {
-          expect(
-            isDescriptorValueValid(checkActualValueCheckMode, invalidDescriptorValue, false)
-          ).toBe(false);
+          expect(isDescriptorValueValid(checkActualValueCheckMode, invalidDescriptorValue)).toBe(
+            false
+          );
         });
-      });
-    });
-
-    test('Should be independent of isCheckAsObject argument', () => {
-      const validDescriptorValue = undefined;
-      const invalidDescriptorValue = true;
-
-      CHECK_ACTUAL_VALUE_CHECK_MODES.forEach((checkActualValueCheckMode) => {
-        expect(isDescriptorValueValid(checkActualValueCheckMode, validDescriptorValue, false)).toBe(
-          true
-        );
-        expect(isDescriptorValueValid(checkActualValueCheckMode, validDescriptorValue, true)).toBe(
-          true
-        );
-
-        expect(
-          isDescriptorValueValid(checkActualValueCheckMode, invalidDescriptorValue, false)
-        ).toBe(false);
-        expect(isDescriptorValueValid(checkActualValueCheckMode, validDescriptorValue, true)).toBe(
-          true
-        );
       });
     });
   });
 
   describe('compareWithDescriptorAnyValue checkModes', () => {
-    test('Should correctly validate descriptor value for mapped entity', () => {
+    test('Should correctly validate descriptor value for primitives, non plain objects, non arrays', () => {
       const validDescriptorValues = [true, 1, 'string', null];
-      const invalidDescriptorValues = [undefined, {}, [], () => {}, /\d/];
+      const invalidDescriptorValues = [undefined, () => {}, /\d/];
 
       COMPARE_WITH_DESCRIPTOR_ANY_VALUE_CHECK_MODES.forEach(
         (compareWithDescriptorValueCheckMode) => {
           validDescriptorValues.forEach((validDescriptorValue) => {
             expect(
-              isDescriptorValueValid(
-                compareWithDescriptorValueCheckMode,
-                validDescriptorValue,
-                false
-              )
+              isDescriptorValueValid(compareWithDescriptorValueCheckMode, validDescriptorValue)
             ).toBe(true);
           });
 
           invalidDescriptorValues.forEach((invalidDescriptorValue) => {
             expect(
-              isDescriptorValueValid(
-                compareWithDescriptorValueCheckMode,
-                invalidDescriptorValue,
-                false
-              )
+              isDescriptorValueValid(compareWithDescriptorValueCheckMode, invalidDescriptorValue)
             ).toBe(false);
           });
         }
       );
     });
 
-    test('Should correctly validate top level descriptor flatten value for plain entity', () => {
-      const validDescriptorValues = [{}, []];
-      const invalidDescriptorValues = [true, 1, 'string', null, undefined, () => {}, /\d/];
-
-      COMPARE_WITH_DESCRIPTOR_ANY_VALUE_CHECK_MODES.forEach(
-        (compareWithDescriptorValueCheckMode) => {
-          validDescriptorValues.forEach((validDescriptorValue) => {
-            expect(
-              isDescriptorValueValid(
-                compareWithDescriptorValueCheckMode,
-                validDescriptorValue,
-                true
-              )
-            ).toBe(true);
-          });
-
-          invalidDescriptorValues.forEach((invalidDescriptorValue) => {
-            expect(
-              isDescriptorValueValid(
-                compareWithDescriptorValueCheckMode,
-                invalidDescriptorValue,
-                true
-              )
-            ).toBe(false);
-          });
-        }
-      );
-    });
-
-    test('Should correctly validate property level descriptor flatten value for plain entity', () => {
-      const validDescriptorValues = [true, 1, 'string', null];
-      const invalidDescriptorValues = [{}, [], undefined, () => {}, /\d/];
-
-      COMPARE_WITH_DESCRIPTOR_ANY_VALUE_CHECK_MODES.forEach(
-        (compareWithDescriptorValueCheckMode) => {
-          validDescriptorValues.forEach((validDescriptorValue) => {
-            expect(
-              isDescriptorValueValid(
-                compareWithDescriptorValueCheckMode,
-                validDescriptorValue,
-                false
-              )
-            ).toBe(true);
-          });
-
-          invalidDescriptorValues.forEach((invalidDescriptorValue) => {
-            expect(
-              isDescriptorValueValid(
-                compareWithDescriptorValueCheckMode,
-                invalidDescriptorValue,
-                false
-              )
-            ).toBe(false);
-          });
-        }
-      );
-    });
-
-    test('Should correctly validate descriptor nested value for plain entity', () => {
+    test('Should correctly validate descriptor value for plain objects, arrays', () => {
       const validNestedDescriptorValues = [true, 1, 'string', null, {}, []];
       const invalidNestedDescriptorValues = [undefined, () => {}, /\d/];
 
@@ -143,36 +54,28 @@ describe('isDescriptorValueValid', () => {
         (compareWithDescriptorValueCheckMode) => {
           validNestedDescriptorValues.forEach((validNestedDescriptorValue) => {
             expect(
-              isDescriptorValueValid(
-                compareWithDescriptorValueCheckMode,
-                { key: validNestedDescriptorValue },
-                true
-              )
+              isDescriptorValueValid(compareWithDescriptorValueCheckMode, {
+                key: validNestedDescriptorValue
+              })
             ).toBe(true);
             expect(
-              isDescriptorValueValid(
-                compareWithDescriptorValueCheckMode,
-                [validNestedDescriptorValue],
-                true
-              )
+              isDescriptorValueValid(compareWithDescriptorValueCheckMode, [
+                validNestedDescriptorValue
+              ])
             ).toBe(true);
           });
 
           invalidNestedDescriptorValues.forEach((invalidNestedDescriptorValue) => {
             expect(
-              isDescriptorValueValid(
-                compareWithDescriptorValueCheckMode,
-                { key: invalidNestedDescriptorValue },
-                true
-              )
+              isDescriptorValueValid(compareWithDescriptorValueCheckMode, {
+                key: invalidNestedDescriptorValue
+              })
             ).toBe(false);
 
             expect(
-              isDescriptorValueValid(
-                compareWithDescriptorValueCheckMode,
-                [invalidNestedDescriptorValue],
-                true
-              )
+              isDescriptorValueValid(compareWithDescriptorValueCheckMode, [
+                invalidNestedDescriptorValue
+              ])
             ).toBe(false);
           });
         }
@@ -191,8 +94,7 @@ describe('isDescriptorValueValid', () => {
             expect(
               isDescriptorValueValid(
                 compareWithDescriptorStringValueCheckMode,
-                validDescriptorValue,
-                false
+                validDescriptorValue
               )
             ).toBe(true);
           });
@@ -201,100 +103,38 @@ describe('isDescriptorValueValid', () => {
             expect(
               isDescriptorValueValid(
                 compareWithDescriptorStringValueCheckMode,
-                invalidDescriptorValue,
-                false
+                invalidDescriptorValue
               )
             ).toBe(false);
           });
         }
       );
     });
-
-    test('Should be independent of isCheckAsObject argument', () => {
-      const validDescriptorValue = 'string';
-      const invalidDescriptorValue = null;
-
-      COMPARE_WITH_DESCRIPTOR_STRING_VALUE_CHECK_MODES.forEach(
-        (compareWithDescriptorStringValueCheckMode) => {
-          expect(
-            isDescriptorValueValid(
-              compareWithDescriptorStringValueCheckMode,
-              validDescriptorValue,
-              false
-            )
-          ).toBe(true);
-          expect(
-            isDescriptorValueValid(
-              compareWithDescriptorStringValueCheckMode,
-              validDescriptorValue,
-              true
-            )
-          ).toBe(true);
-
-          expect(
-            isDescriptorValueValid(
-              compareWithDescriptorStringValueCheckMode,
-              invalidDescriptorValue,
-              false
-            )
-          ).toBe(false);
-          expect(
-            isDescriptorValueValid(
-              compareWithDescriptorStringValueCheckMode,
-              invalidDescriptorValue,
-              true
-            )
-          ).toBe(false);
-        }
-      );
-    });
   });
 
   describe('function checkMode', () => {
-    test('Should correctly validate descriptor value for function checkMode', () => {
+    test('Should correctly validate descriptor value', () => {
       const validDescriptorValue = () => {};
       const invalidDescriptorValues = [true, 1, 'string', null, undefined, {}, [], /\d/];
 
-      expect(isDescriptorValueValid('function', validDescriptorValue, false)).toBe(true);
+      expect(isDescriptorValueValid('function', validDescriptorValue)).toBe(true);
 
       invalidDescriptorValues.forEach((invalidDescriptorValue) => {
-        expect(isDescriptorValueValid('function', invalidDescriptorValue, false)).toBe(false);
+        expect(isDescriptorValueValid('function', invalidDescriptorValue)).toBe(false);
       });
-    });
-
-    test('Should be independent of isCheckAsObject argument', () => {
-      const validDescriptorValue = () => {};
-      const invalidDescriptorValue = true;
-
-      expect(isDescriptorValueValid('function', validDescriptorValue, false)).toBe(true);
-      expect(isDescriptorValueValid('function', validDescriptorValue, true)).toBe(true);
-
-      expect(isDescriptorValueValid('function', invalidDescriptorValue, false)).toBe(false);
-      expect(isDescriptorValueValid('function', invalidDescriptorValue, true)).toBe(false);
     });
   });
 
   describe('regExp checkMode', () => {
-    test('Should correctly validate descriptor value for regExp checkMode', () => {
+    test('Should correctly validate descriptor value', () => {
       const validDescriptorValue = /\d/;
       const invalidDescriptorValues = [true, 1, 'string', null, undefined, {}, [], () => {}];
 
-      expect(isDescriptorValueValid('regExp', validDescriptorValue, false)).toBe(true);
+      expect(isDescriptorValueValid('regExp', validDescriptorValue)).toBe(true);
 
       invalidDescriptorValues.forEach((invalidDescriptorValue) => {
-        expect(isDescriptorValueValid('regExp', invalidDescriptorValue, false)).toBe(false);
+        expect(isDescriptorValueValid('regExp', invalidDescriptorValue)).toBe(false);
       });
-    });
-
-    test('Should be independent of isCheckAsObject argument', () => {
-      const validDescriptorValue = /\d/;
-      const invalidDescriptorValue = true;
-
-      expect(isDescriptorValueValid('regExp', validDescriptorValue, false)).toBe(true);
-      expect(isDescriptorValueValid('regExp', validDescriptorValue, true)).toBe(true);
-
-      expect(isDescriptorValueValid('regExp', invalidDescriptorValue, false)).toBe(false);
-      expect(isDescriptorValueValid('regExp', invalidDescriptorValue, true)).toBe(false);
     });
   });
 });

--- a/bin/validateMockServerConfig/helpers/isDescriptorValueValid/isDescriptorValueValid.ts
+++ b/bin/validateMockServerConfig/helpers/isDescriptorValueValid/isDescriptorValueValid.ts
@@ -13,7 +13,7 @@ import type {
 
 // ✅ important:
 // should validate all properties over nesting
-const isObjectOrArrayValid = (objectOrPrimitive: unknown): boolean => {
+const isObjectValid = (objectOrPrimitive: unknown): boolean => {
   if (
     typeof objectOrPrimitive === 'boolean' ||
     typeof objectOrPrimitive === 'number' ||
@@ -24,12 +24,12 @@ const isObjectOrArrayValid = (objectOrPrimitive: unknown): boolean => {
   }
 
   if (Array.isArray(objectOrPrimitive)) {
-    return objectOrPrimitive.every(isObjectOrArrayValid);
+    return objectOrPrimitive.every(isObjectValid);
   }
 
   if (isPlainObject(objectOrPrimitive)) {
     for (const key in objectOrPrimitive) {
-      if (!isObjectOrArrayValid(objectOrPrimitive[key])) {
+      if (!isObjectValid(objectOrPrimitive[key])) {
         return false;
       }
     }
@@ -44,8 +44,9 @@ export const isDescriptorValueValid = (
   value: unknown,
   isCheckAsObject: boolean
 ) => {
-  if (CHECK_ACTUAL_VALUE_CHECK_MODES.includes(checkMode as CheckActualValueCheckMode))
+  if (CHECK_ACTUAL_VALUE_CHECK_MODES.includes(checkMode as CheckActualValueCheckMode)) {
     return typeof value === 'undefined';
+  }
 
   if (
     COMPARE_WITH_DESCRIPTOR_ANY_VALUE_CHECK_MODES.includes(
@@ -53,8 +54,8 @@ export const isDescriptorValueValid = (
     )
   ) {
     if (isCheckAsObject) {
-      const isValueValidOnTopLevel = isPlainObject(value) || Array.isArray(value);
-      return isValueValidOnTopLevel && isObjectOrArrayValid(value);
+      const isValueObject = isPlainObject(value) || Array.isArray(value);
+      return isValueObject && isObjectValid(value);
     }
     return (
       typeof value === 'boolean' ||

--- a/bin/validateMockServerConfig/helpers/isDescriptorValueValid/isDescriptorValueValid.ts
+++ b/bin/validateMockServerConfig/helpers/isDescriptorValueValid/isDescriptorValueValid.ts
@@ -68,6 +68,6 @@ export const isDescriptorValueValid = (checkMode: CheckMode, value: unknown) => 
     return typeof value === 'boolean' || typeof value === 'number' || typeof value === 'string';
   }
 
-  if (checkMode === 'function') return typeof value === 'function';
+  if (checkMode === 'function') return typeof value === 'function' && value.length <= 2;
   if (checkMode === 'regExp') return value instanceof RegExp;
 };

--- a/bin/validateMockServerConfig/helpers/isDescriptorValueValid/isDescriptorValueValid.ts
+++ b/bin/validateMockServerConfig/helpers/isDescriptorValueValid/isDescriptorValueValid.ts
@@ -13,23 +13,23 @@ import type {
 
 // ✅ important:
 // should validate all properties over nesting
-const isObjectValid = (objectOrPrimitive: unknown): boolean => {
+const isObjectOrArrayValid = (value: unknown): boolean => {
   if (
-    typeof objectOrPrimitive === 'boolean' ||
-    typeof objectOrPrimitive === 'number' ||
-    typeof objectOrPrimitive === 'string' ||
-    objectOrPrimitive === null
+    typeof value === 'boolean' ||
+    typeof value === 'number' ||
+    typeof value === 'string' ||
+    value === null
   ) {
     return true;
   }
 
-  if (Array.isArray(objectOrPrimitive)) {
-    return objectOrPrimitive.every(isObjectValid);
+  if (Array.isArray(value)) {
+    return value.every(isObjectOrArrayValid);
   }
 
-  if (isPlainObject(objectOrPrimitive)) {
-    for (const key in objectOrPrimitive) {
-      if (!isObjectValid(objectOrPrimitive[key])) {
+  if (isPlainObject(value)) {
+    for (const key in value) {
+      if (!isObjectOrArrayValid(value[key])) {
         return false;
       }
     }
@@ -39,11 +39,7 @@ const isObjectValid = (objectOrPrimitive: unknown): boolean => {
   return false;
 };
 
-export const isDescriptorValueValid = (
-  checkMode: CheckMode,
-  value: unknown,
-  isCheckAsObject: boolean
-) => {
+export const isDescriptorValueValid = (checkMode: CheckMode, value: unknown) => {
   if (CHECK_ACTUAL_VALUE_CHECK_MODES.includes(checkMode as CheckActualValueCheckMode)) {
     return typeof value === 'undefined';
   }
@@ -53,9 +49,8 @@ export const isDescriptorValueValid = (
       checkMode as CompareWithDescriptorAnyValueCheckMode
     )
   ) {
-    if (isCheckAsObject) {
-      return (isPlainObject(value) || Array.isArray(value)) && isObjectValid(value);
-    }
+    const isValueObjectOrArray = isPlainObject(value) || Array.isArray(value);
+    if (isValueObjectOrArray) return isObjectOrArrayValid(value);
 
     return (
       typeof value === 'boolean' ||

--- a/bin/validateMockServerConfig/helpers/isDescriptorValueValid/isDescriptorValueValid.ts
+++ b/bin/validateMockServerConfig/helpers/isDescriptorValueValid/isDescriptorValueValid.ts
@@ -54,9 +54,9 @@ export const isDescriptorValueValid = (
     )
   ) {
     if (isCheckAsObject) {
-      const isValueObject = isPlainObject(value) || Array.isArray(value);
-      return isValueObject && isObjectValid(value);
+      return (isPlainObject(value) || Array.isArray(value)) && isObjectValid(value);
     }
+
     return (
       typeof value === 'boolean' ||
       typeof value === 'number' ||

--- a/bin/validateMockServerConfig/validateGraphqlConfig/validateGraphqlConfig.test.ts
+++ b/bin/validateMockServerConfig/validateGraphqlConfig/validateGraphqlConfig.test.ts
@@ -16,6 +16,49 @@ describe('validateGraphqlConfig', () => {
     });
   });
 
+  test('Should handle graphql config only if it contains operationName or query', () => {
+    const correctGraphqlConfigs = [
+      {
+        configs: [
+          {
+            operationType: 'query',
+            operationName: 'user',
+            routes: []
+          }
+        ]
+      },
+      {
+        configs: [
+          {
+            operationType: 'query',
+            query: 'query GetUsers { users { name } }',
+            routes: []
+          }
+        ]
+      },
+      {
+        configs: [
+          {
+            operationType: 'query',
+            operationName: 'user',
+            query: 'query GetUsers { users { name } }',
+            routes: []
+          }
+        ]
+      }
+    ];
+    correctGraphqlConfigs.forEach((correctGraphqlConfig) => {
+      expect(() => validateGraphqlConfig(correctGraphqlConfig)).not.toThrow(Error);
+    });
+
+    const incorrectGraphqlConfigs = [{ configs: [{ operationType: 'query', routes: [] }] }];
+    incorrectGraphqlConfigs.forEach((incorrectGraphqlConfig) => {
+      expect(() => validateGraphqlConfig(incorrectGraphqlConfig)).toThrow(
+        new Error('graphql.configs[0]')
+      );
+    });
+  });
+
   test('Should correctly handle operation type only with correct type', () => {
     const correctOperationTypeValues = ['query', 'mutation'];
     correctOperationTypeValues.forEach((correctOperationTypeValue) => {
@@ -49,13 +92,14 @@ describe('validateGraphqlConfig', () => {
   });
 
   test('Should correctly handle operation name only with correct type', () => {
-    const correctOperationNameValues = ['user', /user/];
+    const correctOperationNameValues = ['user', /user/, undefined];
     correctOperationNameValues.forEach((correctOperationNameValue) => {
       expect(() =>
         validateGraphqlConfig({
           configs: [
             {
               operationType: 'query',
+              query: 'query GetUsers { users { name } }',
               operationName: correctOperationNameValue,
               routes: []
             }
@@ -64,19 +108,54 @@ describe('validateGraphqlConfig', () => {
       ).not.toThrow(Error);
     });
 
-    const incorrectOperationNameValues = [true, 3000, null, undefined, {}, [], () => {}];
+    const incorrectOperationNameValues = [true, 3000, null, {}, [], () => {}];
     incorrectOperationNameValues.forEach((incorrectOperationNameValue) => {
       expect(() =>
         validateGraphqlConfig({
           configs: [
             {
               operationType: 'query',
+              query: 'query GetUsers { users { name } }',
               operationName: incorrectOperationNameValue,
               routes: []
             }
           ]
         })
       ).toThrow('graphql.configs[0].operationName');
+    });
+  });
+
+  test('Shouldcorrectly handle operation query only with correct type', () => {
+    const correctQueryValues = ['query GetUsers { users { name } }', undefined];
+    correctQueryValues.forEach((correctQueryValue) => {
+      expect(() =>
+        validateGraphqlConfig({
+          configs: [
+            {
+              operationType: 'query',
+              operationName: 'GetUsers',
+              query: correctQueryValue,
+              routes: []
+            }
+          ]
+        })
+      ).not.toThrow(Error);
+    });
+
+    const incorrectQueryValues = [true, 3000, null, {}, [], () => {}];
+    incorrectQueryValues.forEach((incorrectQueryValue) => {
+      expect(() =>
+        validateGraphqlConfig({
+          configs: [
+            {
+              operationType: 'query',
+              operationName: 'GetUsers',
+              query: incorrectQueryValue,
+              routes: []
+            }
+          ]
+        })
+      ).toThrow('graphql.configs[0].query');
     });
   });
 });

--- a/bin/validateMockServerConfig/validateGraphqlConfig/validateGraphqlConfig.test.ts
+++ b/bin/validateMockServerConfig/validateGraphqlConfig/validateGraphqlConfig.test.ts
@@ -125,7 +125,7 @@ describe('validateGraphqlConfig', () => {
     });
   });
 
-  test('Shouldcorrectly handle operation query only with correct type', () => {
+  test('Should correctly handle operation query only with correct type', () => {
     const correctQueryValues = ['query GetUsers { users { name } }', undefined];
     correctQueryValues.forEach((correctQueryValue) => {
       expect(() =>

--- a/bin/validateMockServerConfig/validateGraphqlConfig/validateGraphqlConfig.ts
+++ b/bin/validateMockServerConfig/validateGraphqlConfig/validateGraphqlConfig.ts
@@ -9,16 +9,26 @@ const validateConfigs = (configs: unknown) => {
   const isConfigsArray = Array.isArray(configs);
   if (isConfigsArray) {
     configs.forEach((config, index) => {
-      const { operationType, operationName } = config;
+      const { operationType, operationName, query } = config;
+
+      if (typeof operationName === 'undefined' && typeof query === 'undefined') {
+        throw new Error(`configs[${index}]`);
+      }
 
       if (operationType !== 'query' && operationType !== 'mutation') {
         throw new Error(`configs[${index}].operationType`);
       }
 
-      const isOperationNameStringOrRegExp =
-        typeof operationName === 'string' || operationName instanceof RegExp;
-      if (!isOperationNameStringOrRegExp) {
+      if (
+        typeof operationName !== 'undefined' &&
+        typeof operationName !== 'string' &&
+        !(operationName instanceof RegExp)
+      ) {
         throw new Error(`configs[${index}].operationName`);
+      }
+
+      if (typeof query !== 'undefined' && typeof query !== 'string') {
+        throw new Error(`configs[${index}].query`);
       }
 
       try {

--- a/bin/validateMockServerConfig/validateGraphqlConfig/validateRoutes/validateRoutes.test.ts
+++ b/bin/validateMockServerConfig/validateGraphqlConfig/validateRoutes/validateRoutes.test.ts
@@ -422,8 +422,70 @@ describe('validateRoutes (graphql)', () => {
     });
   });
 
+  test('Should correctly handle variables entity only with correct type', () => {
+    const correctVariablesValues = [[], {}];
+    correctVariablesValues.forEach((correctVariablesValue) => {
+      expect(() =>
+        validateRoutes(
+          [
+            {
+              entities: { variables: correctVariablesValue },
+              data: null
+            }
+          ],
+          'query'
+        )
+      ).not.toThrow(Error);
+    });
+
+    const incorrectVariablesValues = ['string', 3000, true, null, undefined, () => {}, /\d/];
+    incorrectVariablesValues.forEach((incorrectVariablesValue) => {
+      expect(() =>
+        validateRoutes(
+          [
+            {
+              entities: { variables: incorrectVariablesValue },
+              data: null
+            }
+          ],
+          'query'
+        )
+      ).toThrow(new Error('routes[0].entities.variables'));
+    });
+
+    const correctVariablesMappedValues = [{}, [], 'string', 3000, true, null];
+    correctVariablesMappedValues.forEach((correctVariablesMappedValue) => {
+      expect(() =>
+        validateRoutes(
+          [
+            {
+              entities: { variables: { key: correctVariablesMappedValue } },
+              data: null
+            }
+          ],
+          'query'
+        )
+      ).not.toThrow(Error);
+    });
+
+    const incorrectVariablesMappedValues = [undefined, () => {}, /\d/];
+    incorrectVariablesMappedValues.forEach((incorrectVariablesMappedValue) => {
+      expect(() =>
+        validateRoutes(
+          [
+            {
+              entities: { variables: { key: incorrectVariablesMappedValue } },
+              data: null
+            }
+          ],
+          'query'
+        )
+      ).toThrow(new Error('routes[0].entities.variables.key'));
+    });
+  });
+
   test('Should correctly handle headers entity only with correct type', () => {
-    const correctHeadersMappedValues = ['string'];
+    const correctHeadersMappedValues = ['string', 3000, true, null];
     correctHeadersMappedValues.forEach((correctHeadersMappedValue) => {
       expect(() =>
         validateRoutes(
@@ -470,7 +532,7 @@ describe('validateRoutes (graphql)', () => {
   });
 
   test('Should correctly handle cookies entity only with correct type', () => {
-    const correctCookiesMappedValues = ['string', 3000, true];
+    const correctCookiesMappedValues = ['string', 3000, true, null];
     correctCookiesMappedValues.forEach((correctCookiesMappedValue) => {
       expect(() =>
         validateRoutes(
@@ -517,7 +579,7 @@ describe('validateRoutes (graphql)', () => {
   });
 
   test('Should correctly handle query entity only with correct type', () => {
-    const correctQueryMappedValues = ['string', 3000, true];
+    const correctQueryMappedValues = ['string', 3000, true, null];
     correctQueryMappedValues.forEach((correctQueryMappedValue) => {
       expect(() =>
         validateRoutes(

--- a/bin/validateMockServerConfig/validateGraphqlConfig/validateRoutes/validateRoutes.test.ts
+++ b/bin/validateMockServerConfig/validateGraphqlConfig/validateRoutes/validateRoutes.test.ts
@@ -1,4 +1,8 @@
-import { CHECK_MODES, PLAIN_ENTITY_CHECK_MODES } from '@/utils/constants';
+import {
+  CHECK_MODES,
+  COMPARE_WITH_DESCRIPTOR_VALUE_CHECK_MODES,
+  PLAIN_ENTITY_CHECK_MODES
+} from '@/utils/constants';
 import type { CompareWithDescriptorValueCheckMode, GraphQLEntityName } from '@/utils/types';
 
 import { validateRoutes } from './validateRoutes';
@@ -12,16 +16,14 @@ const generateCorrectCompareWithDescriptorValueMappedEntity = (
   [`${checkMode}-array`]: { checkMode, value: [true, 1, 'string'] }
 });
 
-const generateAllCorrectCompareWithExpectedValueMappedEntities = () => ({
-  ...generateCorrectCompareWithDescriptorValueMappedEntity('equals'),
-  ...generateCorrectCompareWithDescriptorValueMappedEntity('notEquals'),
-  ...generateCorrectCompareWithDescriptorValueMappedEntity('includes'),
-  ...generateCorrectCompareWithDescriptorValueMappedEntity('notIncludes'),
-  ...generateCorrectCompareWithDescriptorValueMappedEntity('startsWith'),
-  ...generateCorrectCompareWithDescriptorValueMappedEntity('notStartsWith'),
-  ...generateCorrectCompareWithDescriptorValueMappedEntity('endsWith'),
-  ...generateCorrectCompareWithDescriptorValueMappedEntity('notEndsWith')
-});
+const generateAllCorrectCompareWithExpectedValueMappedEntities = () =>
+  COMPARE_WITH_DESCRIPTOR_VALUE_CHECK_MODES.reduce(
+    (acc, checkMode) => ({
+      ...acc,
+      ...generateCorrectCompareWithDescriptorValueMappedEntity(checkMode)
+    }),
+    {}
+  );
 
 describe('validateRoutes (graphql)', () => {
   test('Should correctly handle routes only with correct type', () => {

--- a/bin/validateMockServerConfig/validateGraphqlConfig/validateRoutes/validateRoutes.test.ts
+++ b/bin/validateMockServerConfig/validateGraphqlConfig/validateRoutes/validateRoutes.test.ts
@@ -466,6 +466,17 @@ describe('validateRoutes (graphql)', () => {
           'query'
         )
       ).not.toThrow(Error);
+      expect(() =>
+        validateRoutes(
+          [
+            {
+              entities: { variables: { key: [correctVariablesMappedValue] } },
+              data: null
+            }
+          ],
+          'query'
+        )
+      ).not.toThrow(Error);
     });
 
     const incorrectVariablesMappedValues = [undefined, () => {}, /\d/];
@@ -481,6 +492,17 @@ describe('validateRoutes (graphql)', () => {
           'query'
         )
       ).toThrow(new Error('routes[0].entities.variables.key'));
+      expect(() =>
+        validateRoutes(
+          [
+            {
+              entities: { variables: { key: [incorrectVariablesMappedValue] } },
+              data: null
+            }
+          ],
+          'query'
+        )
+      ).toThrow(new Error('routes[0].entities.variables.key[0]'));
     });
   });
 

--- a/bin/validateMockServerConfig/validateGraphqlConfig/validateRoutes/validateRoutes.test.ts
+++ b/bin/validateMockServerConfig/validateGraphqlConfig/validateRoutes/validateRoutes.test.ts
@@ -26,56 +26,345 @@ const generateAllCorrectCompareWithExpectedValueMappedEntities = () =>
   );
 
 describe('validateRoutes (graphql)', () => {
-  test('Should correctly handle routes only with correct type', () => {
-    expect(() => validateRoutes([{ data: null }], 'query')).not.toThrow(Error);
+  describe('validateRoutes (graphql): validate routes and entities types', () => {
+    test('Should correctly handle routes only with correct type', () => {
+      const correctRoutesValues = [[]];
+      correctRoutesValues.forEach((correctRouteValue) => {
+        expect(() => validateRoutes(correctRouteValue, 'query')).not.toThrow(Error);
+      });
 
-    const incorrectRouteArrayValues = ['string', true, 3000, null, undefined, {}, () => {}, /\d/];
-    incorrectRouteArrayValues.forEach((incorrectRouteArrayValue) => {
-      expect(() => validateRoutes(incorrectRouteArrayValue, 'query')).toThrow(new Error('routes'));
+      const incorrectRoutesValues = ['string', true, 3000, null, undefined, {}, () => {}, /\d/];
+      incorrectRoutesValues.forEach((incorrectRoutesValue) => {
+        expect(() => validateRoutes(incorrectRoutesValue, 'query')).toThrow(new Error('routes'));
+      });
+
+      const correctRouteElementValues = [{ data: null }];
+      correctRouteElementValues.forEach((correctRouteElementValue) => {
+        expect(() => validateRoutes([correctRouteElementValue], 'query')).not.toThrow(Error);
+      });
+
+      const incorrectRouteElementValues = [
+        'string',
+        true,
+        3000,
+        null,
+        undefined,
+        {},
+        [],
+        () => {},
+        /\d/
+      ];
+      incorrectRouteElementValues.forEach((incorrectRouteElementValue) => {
+        expect(() => validateRoutes([incorrectRouteElementValue], 'query')).toThrow(
+          new Error('routes[0]')
+        );
+      });
     });
 
-    const incorrectRouteValues = ['string', true, 3000, null, undefined, {}, [], () => {}, /\d/];
-    incorrectRouteValues.forEach((incorrectRouteValue) => {
-      expect(() => validateRoutes([incorrectRouteValue], 'query')).toThrow(new Error('routes[0]'));
+    test('Should correctly handle entities only with correct type', () => {
+      const correctEntitiesValues = [{}, undefined];
+      correctEntitiesValues.forEach((correctEntitiesValue) => {
+        expect(() =>
+          validateRoutes(
+            [
+              {
+                entities: correctEntitiesValue,
+                data: null
+              }
+            ],
+            'query'
+          )
+        ).not.toThrow(Error);
+      });
+
+      const incorrectEntitiesValues = ['string', true, 3000, null, [], () => {}, /\d/];
+      incorrectEntitiesValues.forEach((incorrectEntitiesValue) => {
+        expect(() =>
+          validateRoutes(
+            [
+              {
+                entities: incorrectEntitiesValue,
+                data: null
+              }
+            ],
+            'query'
+          )
+        ).toThrow(new Error('routes[0].entities'));
+      });
+    });
+
+    test('Should correctly handle query|mutation operation type only with correct entities', () => {
+      const correctEntities = ['headers', 'cookies', 'query', 'variables'];
+      correctEntities.forEach((correctEntity) => {
+        expect(() =>
+          validateRoutes(
+            [
+              {
+                entities: { [correctEntity]: { key: 'value' } },
+                data: null
+              }
+            ],
+            'query'
+          )
+        ).not.toThrow(Error);
+        expect(() =>
+          validateRoutes(
+            [
+              {
+                entities: { [correctEntity]: { key: 'value' } },
+                data: null
+              }
+            ],
+            'mutation'
+          )
+        ).not.toThrow(Error);
+      });
+
+      const incorrectEntities = ['other'];
+      incorrectEntities.forEach((incorrectEntity) => {
+        expect(() =>
+          validateRoutes(
+            [
+              {
+                entities: { [incorrectEntity]: { key: 'value' } },
+                data: null
+              }
+            ],
+            'query'
+          )
+        ).toThrow(new Error(`routes[0].entities.${incorrectEntity}`));
+        expect(() =>
+          validateRoutes(
+            [
+              {
+                entities: { [incorrectEntity]: { key: 'value' } },
+                data: null
+              }
+            ],
+            'mutation'
+          )
+        ).toThrow(new Error(`routes[0].entities.${incorrectEntity}`));
+      });
+    });
+
+    test('Should correctly handle variables entity (plain entities) only with correct type', () => {
+      const correctVariablesValues = [[], {}];
+      correctVariablesValues.forEach((correctVariablesValue) => {
+        expect(() =>
+          validateRoutes(
+            [
+              {
+                entities: { variables: correctVariablesValue },
+                data: null
+              }
+            ],
+            'query'
+          )
+        ).not.toThrow(Error);
+      });
+
+      const incorrectVariablesValues = ['string', 3000, true, null, undefined, () => {}, /\d/];
+      incorrectVariablesValues.forEach((incorrectVariablesValue) => {
+        expect(() =>
+          validateRoutes(
+            [
+              {
+                entities: { variables: incorrectVariablesValue },
+                data: null
+              }
+            ],
+            'query'
+          )
+        ).toThrow(new Error('routes[0].entities.variables'));
+      });
+
+      const correctVariablesObjectPropertyValues = [{}, [], 'string', 3000, true, null];
+      correctVariablesObjectPropertyValues.forEach((correctVariablesObjectPropertyValue) => {
+        expect(() =>
+          validateRoutes(
+            [
+              {
+                entities: { variables: { key: correctVariablesObjectPropertyValue } },
+                data: null
+              }
+            ],
+            'query'
+          )
+        ).not.toThrow(Error);
+        expect(() =>
+          validateRoutes(
+            [
+              {
+                entities: { variables: { key: [correctVariablesObjectPropertyValue] } },
+                data: null
+              }
+            ],
+            'query'
+          )
+        ).not.toThrow(Error);
+      });
+
+      const incorrectVariablesObjectPropertyValues = [undefined, () => {}, /\d/];
+      incorrectVariablesObjectPropertyValues.forEach((incorrectVariablesObjectPropertyValue) => {
+        expect(() =>
+          validateRoutes(
+            [
+              {
+                entities: { variables: { key: incorrectVariablesObjectPropertyValue } },
+                data: null
+              }
+            ],
+            'query'
+          )
+        ).toThrow(new Error('routes[0].entities.variables.key'));
+        expect(() =>
+          validateRoutes(
+            [
+              {
+                entities: { variables: { key: [incorrectVariablesObjectPropertyValue] } },
+                data: null
+              }
+            ],
+            'query'
+          )
+        ).toThrow(new Error('routes[0].entities.variables.key[0]'));
+      });
+
+      const correctVariablesArrayPropertyValues = [{}, []];
+      correctVariablesArrayPropertyValues.forEach((correctVariablesArrayPropertyValue) => {
+        expect(() =>
+          validateRoutes(
+            [
+              {
+                entities: { variables: [correctVariablesArrayPropertyValue] },
+                data: null
+              }
+            ],
+            'query'
+          )
+        ).not.toThrow(Error);
+      });
+
+      const incorrectVariablesArrayPropertyValues = [
+        'string',
+        3000,
+        true,
+        null,
+        undefined,
+        () => {},
+        /\d/
+      ];
+      incorrectVariablesArrayPropertyValues.forEach((incorrectVariablesArrayPropertyValue) => {
+        expect(() =>
+          validateRoutes(
+            [
+              {
+                entities: { variables: [incorrectVariablesArrayPropertyValue] },
+                data: null
+              }
+            ],
+            'query'
+          )
+        ).toThrow(new Error('routes[0].entities.variables[0]'));
+      });
+    });
+
+    test('Should correctly handle headers|cookies|query entity (mapped entities) only with correct type', () => {
+      const entities = ['headers', 'cookies', 'query'];
+      entities.forEach((entity) => {
+        const correctEntityValues = [{}];
+        correctEntityValues.forEach((correctEntityValue) => {
+          expect(() =>
+            validateRoutes(
+              [
+                {
+                  entities: { [entity]: correctEntityValue },
+                  data: null
+                }
+              ],
+              'query'
+            )
+          ).not.toThrow(Error);
+        });
+
+        const incorrectEntityValues = ['string', true, 3000, null, undefined, [], () => {}, /\d/];
+        incorrectEntityValues.forEach((incorrectEntityValue) => {
+          expect(() =>
+            validateRoutes(
+              [
+                {
+                  entities: { [entity]: incorrectEntityValue },
+                  data: null
+                }
+              ],
+              'query'
+            )
+          ).toThrow(new Error(`routes[0].entities.${entity}`));
+        });
+
+        const correctEntityPropertyValues = ['string', 3000, true, null];
+        correctEntityPropertyValues.forEach((correctEntityPropertyValue) => {
+          expect(() =>
+            validateRoutes(
+              [
+                {
+                  entities: { [entity]: { key: correctEntityPropertyValue } },
+                  data: null
+                }
+              ],
+              'query'
+            )
+          ).not.toThrow(Error);
+          expect(() =>
+            validateRoutes(
+              [
+                {
+                  entities: { [entity]: { key: [correctEntityPropertyValue] } },
+                  data: null
+                }
+              ],
+              'query'
+            )
+          ).not.toThrow(Error);
+        });
+
+        const incorrectEntityPropertyValues = [undefined, {}, () => {}, /\d/];
+        incorrectEntityPropertyValues.forEach((incorrectEntityPropertyValue) => {
+          expect(() =>
+            validateRoutes(
+              [
+                {
+                  entities: { [entity]: { key: incorrectEntityPropertyValue } },
+                  data: null
+                }
+              ],
+              'query'
+            )
+          ).toThrow(new Error(`routes[0].entities.${entity}.key`));
+          expect(() =>
+            validateRoutes(
+              [
+                {
+                  entities: { [entity]: { key: [incorrectEntityPropertyValue] } },
+                  data: null
+                }
+              ],
+              'query'
+            )
+          ).toThrow(new Error(`routes[0].entities.${entity}.key[0]`));
+        });
+      });
     });
   });
 
-  test('Should correctly handle entities only with correct type', () => {
-    const correctMappedEntity = {
-      exists: { checkMode: 'exists' },
-
-      notExists: { checkMode: 'notExists' },
-
-      'equals-plain-boolean': true,
-      'equals-plain-number': 1,
-      'equals-plain-string': 'string',
-      'equals-plain-array': [true, 1, 'string'],
-      ...generateAllCorrectCompareWithExpectedValueMappedEntities(),
-
-      'regExp-value': { checkMode: 'regExp', value: /^regExp$/ },
-      'regExp-array': { checkMode: 'regExp', value: [/^regExp1$/, /^regExp2$/] },
-
-      function: {
-        checkMode: 'function',
-        value: (actualValue: string) => actualValue === 'actualValue'
-      }
-    };
-
-    const correctEntitiesValues = [
-      {},
-      {
-        headers: correctMappedEntity,
-        cookies: correctMappedEntity,
-        query: correctMappedEntity
-      },
-      undefined
-    ];
-    correctEntitiesValues.forEach((correctEntitiesValue) => {
+  test('Should correctly handle variables entity only with correct type', () => {
+    const correctVariablesValues = [[], {}];
+    correctVariablesValues.forEach((correctVariablesValue) => {
       expect(() =>
         validateRoutes(
           [
             {
-              entities: correctEntitiesValue,
+              entities: { variables: correctVariablesValue },
               data: null
             }
           ],
@@ -84,23 +373,120 @@ describe('validateRoutes (graphql)', () => {
       ).not.toThrow(Error);
     });
 
-    const incorrectEntitiesValues = ['string', true, 3000, null, [], () => {}, /\d/];
-    incorrectEntitiesValues.forEach((incorrectEntitiesValue) => {
+    const incorrectVariablesValues = ['string', 3000, true, null, undefined, () => {}, /\d/];
+    incorrectVariablesValues.forEach((incorrectVariablesValue) => {
       expect(() =>
         validateRoutes(
           [
             {
-              entities: incorrectEntitiesValue,
+              entities: { variables: incorrectVariablesValue },
               data: null
             }
           ],
           'query'
         )
-      ).toThrow(new Error('routes[0].entities'));
+      ).toThrow(new Error('routes[0].entities.variables'));
+    });
+
+    const correctVariablesMappedValues = [{}, [], 'string', 3000, true, null];
+    correctVariablesMappedValues.forEach((correctVariablesMappedValue) => {
+      expect(() =>
+        validateRoutes(
+          [
+            {
+              entities: { variables: { key: correctVariablesMappedValue } },
+              data: null
+            }
+          ],
+          'query'
+        )
+      ).not.toThrow(Error);
+      expect(() =>
+        validateRoutes(
+          [
+            {
+              entities: { variables: { key: [correctVariablesMappedValue] } },
+              data: null
+            }
+          ],
+          'query'
+        )
+      ).not.toThrow(Error);
+    });
+
+    const incorrectVariablesMappedValues = [undefined, () => {}, /\d/];
+    incorrectVariablesMappedValues.forEach((incorrectVariablesMappedValue) => {
+      expect(() =>
+        validateRoutes(
+          [
+            {
+              entities: { variables: { key: incorrectVariablesMappedValue } },
+              data: null
+            }
+          ],
+          'query'
+        )
+      ).toThrow(new Error('routes[0].entities.variables.key'));
+      expect(() =>
+        validateRoutes(
+          [
+            {
+              entities: { variables: { key: [incorrectVariablesMappedValue] } },
+              data: null
+            }
+          ],
+          'query'
+        )
+      ).toThrow(new Error('routes[0].entities.variables.key[0]'));
     });
   });
 
-  describe('Entity descriptors', () => {
+  describe('validateRoutes (graphql): entity descriptors', () => {
+    test('Should correctly handle entities only with correct type', () => {
+      const correctMappedEntity = {
+        exists: { checkMode: 'exists' },
+
+        notExists: { checkMode: 'notExists' },
+
+        'equals-plain-boolean': true,
+        'equals-plain-number': 1,
+        'equals-plain-string': 'string',
+        'equals-plain-array': [true, 1, 'string'],
+        ...generateAllCorrectCompareWithExpectedValueMappedEntities(),
+
+        'regExp-value': { checkMode: 'regExp', value: /^regExp$/ },
+        'regExp-array': { checkMode: 'regExp', value: [/^regExp1$/, /^regExp2$/] },
+
+        function: {
+          checkMode: 'function',
+          value: (actualValue: string) => actualValue === 'actualValue'
+        }
+      };
+
+      const correctEntitiesValues = [
+        {},
+        {
+          headers: correctMappedEntity,
+          cookies: correctMappedEntity,
+          query: correctMappedEntity
+        },
+        undefined
+      ];
+      correctEntitiesValues.forEach((correctEntitiesValue) => {
+        expect(() =>
+          validateRoutes(
+            [
+              {
+                entities: correctEntitiesValue,
+                data: null
+              }
+            ],
+            'query'
+          )
+        ).not.toThrow(Error);
+      });
+    });
+
     test('Should allow only correct descriptor checkModes for mapped entities', () => {
       const MAPPED_ENTITY_NAMES: Exclude<GraphQLEntityName, 'variables'>[] = [
         'headers',
@@ -357,295 +743,6 @@ describe('validateRoutes (graphql)', () => {
           'query'
         )
       ).toThrow(new Error('routes[0].entities.variables.a.b.value'));
-    });
-  });
-
-  test('Should correctly handle query operation type entities only with correct type', () => {
-    const correctEntities = ['headers', 'cookies', 'query', 'variables'];
-    correctEntities.forEach((correctEntity) => {
-      expect(() =>
-        validateRoutes(
-          [
-            {
-              entities: { [correctEntity]: { key: 'value' } },
-              data: null
-            }
-          ],
-          'query'
-        )
-      ).not.toThrow(Error);
-    });
-
-    const incorrectEntities = ['body', 'other'];
-    incorrectEntities.forEach((incorrectEntity) => {
-      expect(() =>
-        validateRoutes(
-          [
-            {
-              entities: { [incorrectEntity]: { key: 'value' } },
-              data: null
-            }
-          ],
-          'query'
-        )
-      ).toThrow(new Error(`routes[0].entities.${incorrectEntity}`));
-    });
-  });
-
-  test('Should correctly handle mutation operation type entities only with correct type', () => {
-    const correctEntities = ['headers', 'cookies', 'query', 'variables'];
-    correctEntities.forEach((correctEntity) => {
-      expect(() =>
-        validateRoutes(
-          [
-            {
-              entities: { [correctEntity]: { key: 'value' } },
-              data: null
-            }
-          ],
-          'mutation'
-        )
-      ).not.toThrow(Error);
-    });
-
-    const incorrectEntities = ['body', 'other'];
-    incorrectEntities.forEach((incorrectEntity) => {
-      expect(() =>
-        validateRoutes(
-          [
-            {
-              entities: { [incorrectEntity]: { key: 'value' } },
-              data: null
-            }
-          ],
-          'mutation'
-        )
-      ).toThrow(new Error(`routes[0].entities.${incorrectEntity}`));
-    });
-  });
-
-  test('Should correctly handle variables entity only with correct type', () => {
-    const correctVariablesValues = [[], {}];
-    correctVariablesValues.forEach((correctVariablesValue) => {
-      expect(() =>
-        validateRoutes(
-          [
-            {
-              entities: { variables: correctVariablesValue },
-              data: null
-            }
-          ],
-          'query'
-        )
-      ).not.toThrow(Error);
-    });
-
-    const incorrectVariablesValues = ['string', 3000, true, null, undefined, () => {}, /\d/];
-    incorrectVariablesValues.forEach((incorrectVariablesValue) => {
-      expect(() =>
-        validateRoutes(
-          [
-            {
-              entities: { variables: incorrectVariablesValue },
-              data: null
-            }
-          ],
-          'query'
-        )
-      ).toThrow(new Error('routes[0].entities.variables'));
-    });
-
-    const correctVariablesMappedValues = [{}, [], 'string', 3000, true, null];
-    correctVariablesMappedValues.forEach((correctVariablesMappedValue) => {
-      expect(() =>
-        validateRoutes(
-          [
-            {
-              entities: { variables: { key: correctVariablesMappedValue } },
-              data: null
-            }
-          ],
-          'query'
-        )
-      ).not.toThrow(Error);
-      expect(() =>
-        validateRoutes(
-          [
-            {
-              entities: { variables: { key: [correctVariablesMappedValue] } },
-              data: null
-            }
-          ],
-          'query'
-        )
-      ).not.toThrow(Error);
-    });
-
-    const incorrectVariablesMappedValues = [undefined, () => {}, /\d/];
-    incorrectVariablesMappedValues.forEach((incorrectVariablesMappedValue) => {
-      expect(() =>
-        validateRoutes(
-          [
-            {
-              entities: { variables: { key: incorrectVariablesMappedValue } },
-              data: null
-            }
-          ],
-          'query'
-        )
-      ).toThrow(new Error('routes[0].entities.variables.key'));
-      expect(() =>
-        validateRoutes(
-          [
-            {
-              entities: { variables: { key: [incorrectVariablesMappedValue] } },
-              data: null
-            }
-          ],
-          'query'
-        )
-      ).toThrow(new Error('routes[0].entities.variables.key[0]'));
-    });
-  });
-
-  test('Should correctly handle headers entity only with correct type', () => {
-    const correctHeadersMappedValues = ['string', 3000, true, null];
-    correctHeadersMappedValues.forEach((correctHeadersMappedValue) => {
-      expect(() =>
-        validateRoutes(
-          [
-            {
-              entities: { headers: { key: correctHeadersMappedValue } },
-              data: null
-            }
-          ],
-          'query'
-        )
-      ).not.toThrow(Error);
-    });
-
-    const incorrectHeadersValues = [true, null, undefined, [], () => {}, /\d/];
-    incorrectHeadersValues.forEach((incorrectHeaderValue) => {
-      expect(() =>
-        validateRoutes(
-          [
-            {
-              entities: { headers: incorrectHeaderValue },
-              data: null
-            }
-          ],
-          'query'
-        )
-      ).toThrow(new Error('routes[0].entities.headers'));
-    });
-
-    const incorrectHeadersMappedValues = [undefined, {}, () => {}, /\d/];
-    incorrectHeadersMappedValues.forEach((incorrectHeadersMappedValue) => {
-      expect(() =>
-        validateRoutes(
-          [
-            {
-              entities: { headers: { key: incorrectHeadersMappedValue } },
-              data: null
-            }
-          ],
-          'query'
-        )
-      ).toThrow(new Error('routes[0].entities.headers.key'));
-    });
-  });
-
-  test('Should correctly handle cookies entity only with correct type', () => {
-    const correctCookiesMappedValues = ['string', 3000, true, null];
-    correctCookiesMappedValues.forEach((correctCookiesMappedValue) => {
-      expect(() =>
-        validateRoutes(
-          [
-            {
-              entities: { cookies: { key: correctCookiesMappedValue } },
-              data: null
-            }
-          ],
-          'query'
-        )
-      ).not.toThrow(Error);
-    });
-
-    const incorrectCookiesValues = [true, 3000, null, undefined, [], () => {}, /\d/];
-    incorrectCookiesValues.forEach((incorrectCookieValue) => {
-      expect(() =>
-        validateRoutes(
-          [
-            {
-              entities: { cookies: incorrectCookieValue },
-              data: null
-            }
-          ],
-          'query'
-        )
-      ).toThrow(new Error('routes[0].entities.cookies'));
-    });
-
-    const incorrectCookiesMappedValues = [undefined, {}, () => {}, /\d/];
-    incorrectCookiesMappedValues.forEach((incorrectCookiesMappedValue) => {
-      expect(() =>
-        validateRoutes(
-          [
-            {
-              entities: { cookies: { key: incorrectCookiesMappedValue } },
-              data: null
-            }
-          ],
-          'query'
-        )
-      ).toThrow(new Error('routes[0].entities.cookies.key'));
-    });
-  });
-
-  test('Should correctly handle query entity only with correct type', () => {
-    const correctQueryMappedValues = ['string', 3000, true, null];
-    correctQueryMappedValues.forEach((correctQueryMappedValue) => {
-      expect(() =>
-        validateRoutes(
-          [
-            {
-              entities: { query: { key: correctQueryMappedValue } },
-              data: null
-            }
-          ],
-          'query'
-        )
-      ).not.toThrow(Error);
-    });
-
-    const incorrectQueryValues = ['string', true, 3000, null, undefined, [], () => {}, /\d/];
-    incorrectQueryValues.forEach((incorrectQueryValue) => {
-      expect(() =>
-        validateRoutes(
-          [
-            {
-              entities: { query: incorrectQueryValue },
-              data: null
-            }
-          ],
-          'query'
-        )
-      ).toThrow(new Error('routes[0].entities.query'));
-    });
-
-    const incorrectQueryMappedValues = [undefined, {}, () => {}, /\d/];
-    incorrectQueryMappedValues.forEach((incorrectQueryMappedValue) => {
-      expect(() =>
-        validateRoutes(
-          [
-            {
-              entities: { query: { key: incorrectQueryMappedValue } },
-              data: null
-            }
-          ],
-          'query'
-        )
-      ).toThrow(new Error('routes[0].entities.query.key'));
     });
   });
 });

--- a/bin/validateMockServerConfig/validateGraphqlConfig/validateRoutes/validateRoutes.test.ts
+++ b/bin/validateMockServerConfig/validateGraphqlConfig/validateRoutes/validateRoutes.test.ts
@@ -215,7 +215,7 @@ describe('validateRoutes (graphql)', () => {
         ).toThrow(new Error('routes[0].entities.headers.key.value'));
       });
 
-      const incorrectMappedEntityValues = [null, {}, () => {}, /\d/];
+      const incorrectMappedEntityValues = [undefined, {}, () => {}, /\d/];
       incorrectMappedEntityValues.forEach((incorrectMappedEntityValue) => {
         expect(() =>
           validateRoutes(
@@ -453,7 +453,7 @@ describe('validateRoutes (graphql)', () => {
       ).toThrow(new Error('routes[0].entities.headers'));
     });
 
-    const incorrectHeadersMappedValues = [null, undefined, {}, () => {}, /\d/];
+    const incorrectHeadersMappedValues = [undefined, {}, () => {}, /\d/];
     incorrectHeadersMappedValues.forEach((incorrectHeadersMappedValue) => {
       expect(() =>
         validateRoutes(
@@ -500,7 +500,7 @@ describe('validateRoutes (graphql)', () => {
       ).toThrow(new Error('routes[0].entities.cookies'));
     });
 
-    const incorrectCookiesMappedValues = [null, undefined, {}, () => {}, /\d/];
+    const incorrectCookiesMappedValues = [undefined, {}, () => {}, /\d/];
     incorrectCookiesMappedValues.forEach((incorrectCookiesMappedValue) => {
       expect(() =>
         validateRoutes(
@@ -547,7 +547,7 @@ describe('validateRoutes (graphql)', () => {
       ).toThrow(new Error('routes[0].entities.query'));
     });
 
-    const incorrectQueryMappedValues = [null, undefined, {}, () => {}, /\d/];
+    const incorrectQueryMappedValues = [undefined, {}, () => {}, /\d/];
     incorrectQueryMappedValues.forEach((incorrectQueryMappedValue) => {
       expect(() =>
         validateRoutes(

--- a/bin/validateMockServerConfig/validateGraphqlConfig/validateRoutes/validateRoutes.ts
+++ b/bin/validateMockServerConfig/validateGraphqlConfig/validateRoutes/validateRoutes.ts
@@ -24,7 +24,12 @@ const validateEntity = (entity: unknown, entityName: GraphQLEntityName) => {
       throw new Error('variables.checkMode');
     }
 
-    if (!isDescriptorValueValid(entity.checkMode, entity.value, true)) {
+    const isDescriptorValueObjectOrArray =
+      isPlainObject(entity.value) || Array.isArray(entity.value);
+    if (
+      !isDescriptorValueObjectOrArray ||
+      !isDescriptorValueValid(entity.checkMode, entity.value)
+    ) {
       throw new Error('variables.value');
     }
 
@@ -46,28 +51,26 @@ const validateEntity = (entity: unknown, entityName: GraphQLEntityName) => {
       const isValueArray = Array.isArray(value);
       if (isValueArray) {
         value.forEach((element, index) => {
-          if (
-            isVariables &&
-            !isDescriptorValueValid(checkMode, element, true) &&
-            !isDescriptorValueValid(checkMode, element, false)
-          ) {
+          if (isVariables) {
+            if (isDescriptorValueValid(checkMode, element)) return;
             throw new Error(`${errorMessage}[${index}]`);
           }
-          if (!isVariables && !isDescriptorValueValid(checkMode, element, false)) {
+
+          const isElementObjectOrArray = isPlainObject(element) || Array.isArray(element);
+          if (isElementObjectOrArray || !isDescriptorValueValid(checkMode, element)) {
             throw new Error(`${errorMessage}[${index}]`);
           }
         });
         return;
       }
 
-      if (
-        isVariables &&
-        !isDescriptorValueValid(checkMode, value, true) &&
-        !isDescriptorValueValid(checkMode, value, false)
-      ) {
+      if (isVariables) {
+        if (isDescriptorValueValid(checkMode, value)) return;
         throw new Error(errorMessage);
       }
-      if (!isVariables && !isDescriptorValueValid(checkMode, value, false)) {
+
+      const isValueObjectOrArray = isPlainObject(value) || Array.isArray(value);
+      if (isValueObjectOrArray || !isDescriptorValueValid(checkMode, value)) {
         throw new Error(errorMessage);
       }
     });

--- a/bin/validateMockServerConfig/validateGraphqlConfig/validateRoutes/validateRoutes.ts
+++ b/bin/validateMockServerConfig/validateGraphqlConfig/validateRoutes/validateRoutes.ts
@@ -1,5 +1,9 @@
 import { convertToEntityDescriptor, isEntityDescriptor, isPlainObject } from '@/utils/helpers';
-import type { GraphQLEntityNamesByOperationType, GraphQLOperationType } from '@/utils/types';
+import type {
+  GraphQLEntityName,
+  GraphQLEntityNamesByOperationType,
+  GraphQLOperationType
+} from '@/utils/types';
 
 import { isCheckModeValid, isDescriptorValueValid } from '../../helpers';
 import { validateInterceptors } from '../../validateInterceptors/validateInterceptors';
@@ -12,28 +16,26 @@ const ALLOWED_ENTITIES_BY_OPERATION_TYPE: AllowedEntityNamesByOperationType = {
   mutation: ['headers', 'cookies', 'query', 'variables']
 };
 
-const validateEntity = (entity: unknown, entityName: string) => {
-  const { checkMode: topLevelCheckMode, value: topLevelValue } = convertToEntityDescriptor(entity);
+const validateEntity = (entity: unknown, entityName: GraphQLEntityName) => {
   const isVariables = entityName === 'variables';
-
   const isTopLevelDescriptor = isEntityDescriptor(entity);
   if (isTopLevelDescriptor && isVariables) {
+    const { checkMode: topLevelCheckMode, value: topLevelValue } = entity;
+
     if (!isCheckModeValid(topLevelCheckMode, 'variables')) {
       throw new Error('variables.checkMode');
     }
 
-    if (!isDescriptorValueValid(topLevelCheckMode, topLevelValue, 'variables')) {
-      const errorMessage = 'variables.value';
-      throw new Error(errorMessage);
+    if (!isDescriptorValueValid(topLevelCheckMode, topLevelValue, true)) {
+      throw new Error('variables.value');
     }
 
     return;
   }
 
-  const isEntityObject = isPlainObject(entity) && !(entity instanceof RegExp);
-  const isEntityArray = Array.isArray(entity) && isVariables;
-  if (isEntityObject || isEntityArray) {
-    Object.entries(topLevelValue).forEach(([key, valueOrDescriptor]) => {
+  const isEntityObject = isPlainObject(entity);
+  if (isEntityObject) {
+    Object.entries(entity).forEach(([key, valueOrDescriptor]) => {
       const { checkMode, value } = convertToEntityDescriptor(valueOrDescriptor);
       if (!isCheckModeValid(checkMode)) {
         throw new Error(`${entityName}.${key}.checkMode`);
@@ -43,15 +45,28 @@ const validateEntity = (entity: unknown, entityName: string) => {
       const errorMessage = `${entityName}.${key}${isDescriptor ? '.value' : ''}`;
 
       const isValueArray = Array.isArray(value);
-      if (isValueArray && !isVariables) {
+      if (isValueArray) {
         value.forEach((element, index) => {
-          if (!isDescriptorValueValid(checkMode, element)) {
+          if (
+            isVariables &&
+            !isDescriptorValueValid(checkMode, element, true) &&
+            !isDescriptorValueValid(checkMode, element, false)
+          ) {
+            throw new Error(`${errorMessage}[${index}]`);
+          } else if (!isDescriptorValueValid(checkMode, element, false)) {
             throw new Error(`${errorMessage}[${index}]`);
           }
         });
         return;
       }
-      if (!isDescriptorValueValid(checkMode, value)) {
+
+      if (
+        isVariables &&
+        !isDescriptorValueValid(checkMode, value, true) &&
+        !isDescriptorValueValid(checkMode, value, false)
+      ) {
+        throw new Error(errorMessage);
+      } else if (!isDescriptorValueValid(checkMode, value, false)) {
         throw new Error(errorMessage);
       }
     });
@@ -73,7 +88,7 @@ const validateEntities = (entities: unknown, operationType: GraphQLOperationType
       }
 
       try {
-        validateEntity(entities[entityName], entityName);
+        validateEntity(entities[entityName], entityName as GraphQLEntityName);
       } catch (error: any) {
         throw new Error(`entities.${error.message}`);
       }

--- a/bin/validateMockServerConfig/validateGraphqlConfig/validateRoutes/validateRoutes.ts
+++ b/bin/validateMockServerConfig/validateGraphqlConfig/validateRoutes/validateRoutes.ts
@@ -52,7 +52,8 @@ const validateEntity = (entity: unknown, entityName: GraphQLEntityName) => {
             !isDescriptorValueValid(checkMode, element, false)
           ) {
             throw new Error(`${errorMessage}[${index}]`);
-          } else if (!isDescriptorValueValid(checkMode, element, false)) {
+          }
+          if (!isVariables && !isDescriptorValueValid(checkMode, element, false)) {
             throw new Error(`${errorMessage}[${index}]`);
           }
         });
@@ -65,7 +66,8 @@ const validateEntity = (entity: unknown, entityName: GraphQLEntityName) => {
         !isDescriptorValueValid(checkMode, value, false)
       ) {
         throw new Error(errorMessage);
-      } else if (!isDescriptorValueValid(checkMode, value, false)) {
+      }
+      if (!isVariables && !isDescriptorValueValid(checkMode, value, false)) {
         throw new Error(errorMessage);
       }
     });

--- a/bin/validateMockServerConfig/validateGraphqlConfig/validateRoutes/validateRoutes.ts
+++ b/bin/validateMockServerConfig/validateGraphqlConfig/validateRoutes/validateRoutes.ts
@@ -26,6 +26,8 @@ const validateEntity = (entity: unknown, entityName: string) => {
       const errorMessage = 'variables.value';
       throw new Error(errorMessage);
     }
+
+    return;
   }
 
   const isEntityObject = isPlainObject(entity) && !(entity instanceof RegExp);

--- a/bin/validateMockServerConfig/validateGraphqlConfig/validateRoutes/validateRoutes.ts
+++ b/bin/validateMockServerConfig/validateGraphqlConfig/validateRoutes/validateRoutes.ts
@@ -32,7 +32,8 @@ const validateEntity = (entity: unknown, entityName: GraphQLEntityName) => {
   }
 
   const isEntityObject = isPlainObject(entity);
-  if (isEntityObject) {
+  const isEntityVariablesArray = Array.isArray(entity) && isVariables;
+  if (isEntityObject || isEntityVariablesArray) {
     Object.entries(entity).forEach(([key, valueOrDescriptor]) => {
       const { checkMode, value } = convertToEntityDescriptor(valueOrDescriptor);
       if (!isCheckModeValid(checkMode)) {

--- a/bin/validateMockServerConfig/validateGraphqlConfig/validateRoutes/validateRoutes.ts
+++ b/bin/validateMockServerConfig/validateGraphqlConfig/validateRoutes/validateRoutes.ts
@@ -20,13 +20,11 @@ const validateEntity = (entity: unknown, entityName: GraphQLEntityName) => {
   const isVariables = entityName === 'variables';
   const isTopLevelDescriptor = isEntityDescriptor(entity);
   if (isTopLevelDescriptor && isVariables) {
-    const { checkMode: topLevelCheckMode, value: topLevelValue } = entity;
-
-    if (!isCheckModeValid(topLevelCheckMode, 'variables')) {
+    if (!isCheckModeValid(entity.checkMode, 'variables')) {
       throw new Error('variables.checkMode');
     }
 
-    if (!isDescriptorValueValid(topLevelCheckMode, topLevelValue, true)) {
+    if (!isDescriptorValueValid(entity.checkMode, entity.value, true)) {
       throw new Error('variables.value');
     }
 

--- a/bin/validateMockServerConfig/validateRestConfig/validateRoutes/validateRoutes.test.ts
+++ b/bin/validateMockServerConfig/validateRestConfig/validateRoutes/validateRoutes.test.ts
@@ -26,49 +26,327 @@ const generateAllCorrectCompareWithExpectedValueMappedEntities = () =>
   );
 
 describe('validateRoutes (rest)', () => {
-  test('Should correctly handle routes only with correct type', () => {
-    expect(() => validateRoutes([{ data: null }], 'get')).not.toThrow(Error);
+  describe('validateRoutes (rest): validate routes and entites types', () => {
+    test('Should correctly handle routes only with correct type', () => {
+      expect(() => validateRoutes([{ data: null }], 'get')).not.toThrow(Error);
 
-    const incorrectRouteArrayValues = ['string', true, 3000, null, undefined, {}, () => {}, /\d/];
-    incorrectRouteArrayValues.forEach((incorrectRouteArrayValue) => {
-      expect(() => validateRoutes(incorrectRouteArrayValue, 'get')).toThrow(new Error('routes'));
+      const incorrectRoutesValues = ['string', true, 3000, null, undefined, {}, () => {}, /\d/];
+      incorrectRoutesValues.forEach((incorrectRoutesValue) => {
+        expect(() => validateRoutes(incorrectRoutesValue, 'get')).toThrow(new Error('routes'));
+      });
+
+      const incorrectRouteElementValues = [
+        'string',
+        true,
+        3000,
+        null,
+        undefined,
+        {},
+        [],
+        () => {},
+        /\d/
+      ];
+      incorrectRouteElementValues.forEach((incorrectRouteElementValue) => {
+        expect(() => validateRoutes([incorrectRouteElementValue], 'get')).toThrow(
+          new Error('routes[0]')
+        );
+      });
     });
 
-    const incorrectRouteValues = ['string', true, 3000, null, undefined, {}, [], () => {}, /\d/];
-    incorrectRouteValues.forEach((incorrectRouteValue) => {
-      expect(() => validateRoutes([incorrectRouteValue], 'get')).toThrow(new Error('routes[0]'));
-    });
-  });
+    test('Should correctly handle entities only with correct type', () => {
+      const correctEntitiesValues = [{}, undefined];
+      correctEntitiesValues.forEach((correctEntitiesValue) => {
+        expect(() =>
+          validateRoutes(
+            [
+              {
+                entities: correctEntitiesValue,
+                data: null
+              }
+            ],
+            'get'
+          )
+        ).not.toThrow(Error);
+      });
 
-  test('Should correctly handle entities only with correct type', () => {
-    const correctEntitiesValues = [{}, undefined];
-    correctEntitiesValues.forEach((correctEntitiesValue) => {
-      expect(() =>
-        validateRoutes(
-          [
-            {
-              entities: correctEntitiesValue,
-              data: null
-            }
-          ],
-          'get'
-        )
-      ).not.toThrow(Error);
+      const incorrectEntitiesValues = ['string', true, 3000, null, [], () => {}, /\d/];
+      incorrectEntitiesValues.forEach((incorrectEntitiesValue) => {
+        expect(() =>
+          validateRoutes(
+            [
+              {
+                entities: incorrectEntitiesValue,
+                data: null
+              }
+            ],
+            'get'
+          )
+        ).toThrow(new Error('routes[0].entities'));
+      });
     });
 
-    const incorrectEntitiesValues = ['string', true, 3000, null, [], () => {}, /\d/];
-    incorrectEntitiesValues.forEach((incorrectEntitiesValue) => {
-      expect(() =>
-        validateRoutes(
-          [
-            {
-              entities: incorrectEntitiesValue,
-              data: null
-            }
-          ],
-          'get'
-        )
-      ).toThrow(new Error('routes[0].entities'));
+    test('Should correctly handle get|delete|options method (methods without body) entities only with correct type', () => {
+      const methods = ['get', 'delete', 'options'] as const;
+      const correctEntities = ['headers', 'cookies', 'params', 'query'];
+      const incorrectEntities = ['body', 'other'];
+
+      methods.forEach((method) => {
+        correctEntities.forEach((correctEntity) => {
+          expect(() =>
+            validateRoutes(
+              [
+                {
+                  entities: { [correctEntity]: { key: 'value' } },
+                  data: null
+                }
+              ],
+              method
+            )
+          ).not.toThrow(Error);
+        });
+        incorrectEntities.forEach((incorrectEntity) => {
+          expect(() =>
+            validateRoutes(
+              [
+                {
+                  entities: { [incorrectEntity]: { key: 'value' } },
+                  data: null
+                }
+              ],
+              method
+            )
+          ).toThrow(new Error(`routes[0].entities.${incorrectEntity}`));
+        });
+      });
+    });
+
+    test('Should correctly handle post|put|patch method (methods with body) entities only with correct type', () => {
+      const methods = ['post', 'put', 'patch'] as const;
+      const correctEntities = ['headers', 'cookies', 'params', 'query', 'body'];
+      const incorrectEntities = ['other'];
+
+      methods.forEach((method) => {
+        correctEntities.forEach((correctEntity) => {
+          expect(() =>
+            validateRoutes(
+              [
+                {
+                  entities: { [correctEntity]: { key: 'value' } },
+                  data: null
+                }
+              ],
+              method
+            )
+          ).not.toThrow(Error);
+        });
+        incorrectEntities.forEach((incorrectEntity) => {
+          expect(() =>
+            validateRoutes(
+              [
+                {
+                  entities: { [incorrectEntity]: { key: 'value' } },
+                  data: null
+                }
+              ],
+              method
+            )
+          ).toThrow(new Error(`routes[0].entities.${incorrectEntity}`));
+        });
+      });
+    });
+
+    test('Should correctly handle body entity (plain entities) only with correct type', () => {
+      const correctBodyValues = [[], {}];
+      correctBodyValues.forEach((correctBodyValue) => {
+        expect(() =>
+          validateRoutes(
+            [
+              {
+                entities: { body: correctBodyValue },
+                data: null
+              }
+            ],
+            'post'
+          )
+        ).not.toThrow(Error);
+      });
+
+      const incorrectBodyValues = ['string', 3000, true, null, undefined, () => {}, /\d/];
+      incorrectBodyValues.forEach((incorrectBodyValue) => {
+        expect(() =>
+          validateRoutes(
+            [
+              {
+                entities: { body: incorrectBodyValue },
+                data: null
+              }
+            ],
+            'post'
+          )
+        ).toThrow(new Error('routes[0].entities.body'));
+      });
+
+      const correctBodyPropertyValues = [{}, [], 'string', 3000, true, null];
+      correctBodyPropertyValues.forEach((correctBodyPropertyValue) => {
+        expect(() =>
+          validateRoutes(
+            [
+              {
+                entities: { body: { key: correctBodyPropertyValue } },
+                data: null
+              }
+            ],
+            'post'
+          )
+        ).not.toThrow(Error);
+        expect(() =>
+          validateRoutes(
+            [
+              {
+                entities: { body: { key: [correctBodyPropertyValue] } },
+                data: null
+              }
+            ],
+            'post'
+          )
+        ).not.toThrow(Error);
+        expect(() =>
+          validateRoutes(
+            [
+              {
+                entities: { body: [correctBodyPropertyValue] },
+                data: null
+              }
+            ],
+            'post'
+          )
+        ).not.toThrow(Error);
+      });
+
+      const incorrectBodyPropertyValues = [undefined, () => {}, /\d/];
+      incorrectBodyPropertyValues.forEach((incorrectBodyPropertyValue) => {
+        expect(() =>
+          validateRoutes(
+            [
+              {
+                entities: { body: { key: incorrectBodyPropertyValue } },
+                data: null
+              }
+            ],
+            'post'
+          )
+        ).toThrow(new Error('routes[0].entities.body.key'));
+        expect(() =>
+          validateRoutes(
+            [
+              {
+                entities: { body: { key: [incorrectBodyPropertyValue] } },
+                data: null
+              }
+            ],
+            'post'
+          )
+        ).toThrow(new Error('routes[0].entities.body.key[0]'));
+        expect(() =>
+          validateRoutes(
+            [
+              {
+                entities: { body: [incorrectBodyPropertyValue] },
+                data: null
+              }
+            ],
+            'post'
+          )
+        ).toThrow(new Error('routes[0].entities.body[0]'));
+      });
+    });
+
+    test('Should correctly handle headers|cookies|params|query entity (mapped entities) only with correct type', () => {
+      const entities = ['headers', 'cookies', 'params', 'query'];
+
+      entities.forEach((entity) => {
+        const correctEntityValues = [{}];
+        correctEntityValues.forEach((correctEntityValue) => {
+          expect(() =>
+            validateRoutes(
+              [
+                {
+                  entities: { [entity]: correctEntityValue },
+                  data: null
+                }
+              ],
+              'get'
+            )
+          ).not.toThrow(Error);
+        });
+
+        const incorrectEntityValues = ['string', true, 3000, null, undefined, [], () => {}, /\d/];
+        incorrectEntityValues.forEach((incorrectEntityValue) => {
+          expect(() =>
+            validateRoutes(
+              [
+                {
+                  entities: { [entity]: incorrectEntityValue },
+                  data: null
+                }
+              ],
+              'get'
+            )
+          ).toThrow(new Error(`routes[0].entities.${entity}`));
+        });
+
+        const correctEntityPropertyValues = ['string', 3000, true, null];
+        correctEntityPropertyValues.forEach((correctEntityPropertyValue) => {
+          expect(() =>
+            validateRoutes(
+              [
+                {
+                  entities: { [entity]: { key: correctEntityPropertyValue } },
+                  data: null
+                }
+              ],
+              'get'
+            )
+          ).not.toThrow(Error);
+          expect(() =>
+            validateRoutes(
+              [
+                {
+                  entities: { [entity]: { key: [correctEntityPropertyValue] } },
+                  data: null
+                }
+              ],
+              'get'
+            )
+          ).not.toThrow(Error);
+        });
+
+        const incorrectEntityPropertyValues = [undefined, {}, () => {}, /\d/];
+        incorrectEntityPropertyValues.forEach((incorrectEntityPropertyValue) => {
+          expect(() =>
+            validateRoutes(
+              [
+                {
+                  entities: { [entity]: { key: incorrectEntityPropertyValue } },
+                  data: null
+                }
+              ],
+              'get'
+            )
+          ).toThrow(new Error(`routes[0].entities.${entity}.key`));
+          expect(() =>
+            validateRoutes(
+              [
+                {
+                  entities: { [entity]: { key: [incorrectEntityPropertyValue] } },
+                  data: null
+                }
+              ],
+              'get'
+            )
+          ).toThrow(new Error(`routes[0].entities.${entity}.key[0]`));
+        });
+      });
     });
   });
 
@@ -391,452 +669,6 @@ describe('validateRoutes (rest)', () => {
           'post'
         )
       ).toThrow(new Error('routes[0].entities.body.a.b.value'));
-    });
-  });
-
-  test('Should correctly handle get|delete|options method entities only with correct type', () => {
-    const correctEntities = ['headers', 'cookies', 'params', 'query'];
-    correctEntities.forEach((correctEntity) => {
-      expect(() =>
-        validateRoutes(
-          [
-            {
-              entities: { [correctEntity]: { key: 'value' } },
-              data: null
-            }
-          ],
-          'get'
-        )
-      ).not.toThrow(Error);
-      expect(() =>
-        validateRoutes(
-          [
-            {
-              entities: { [correctEntity]: { key: 'value' } },
-              data: null
-            }
-          ],
-          'delete'
-        )
-      ).not.toThrow(Error);
-      expect(() =>
-        validateRoutes(
-          [
-            {
-              entities: { [correctEntity]: { key: 'value' } },
-              data: null
-            }
-          ],
-          'options'
-        )
-      ).not.toThrow(Error);
-    });
-
-    const incorrectEntities = ['body', 'other'];
-    incorrectEntities.forEach((incorrectEntity) => {
-      expect(() =>
-        validateRoutes(
-          [
-            {
-              entities: { [incorrectEntity]: { key: 'value' } },
-              data: null
-            }
-          ],
-          'get'
-        )
-      ).toThrow(new Error(`routes[0].entities.${incorrectEntity}`));
-      expect(() =>
-        validateRoutes(
-          [
-            {
-              entities: { [incorrectEntity]: { key: 'value' } },
-              data: null
-            }
-          ],
-          'delete'
-        )
-      ).toThrow(new Error(`routes[0].entities.${incorrectEntity}`));
-    });
-  });
-
-  test('Should correctly handle post|put|patch method entities only with correct type', () => {
-    const correctEntities = ['headers', 'cookies', 'params', 'query'];
-    correctEntities.forEach((correctEntity) => {
-      expect(() =>
-        validateRoutes(
-          [
-            {
-              entities: {
-                [correctEntity]: { key: 'value' },
-                body: { key: 'value' }
-              },
-              data: null
-            }
-          ],
-          'post'
-        )
-      ).not.toThrow(Error);
-      expect(() =>
-        validateRoutes(
-          [
-            {
-              entities: {
-                [correctEntity]: { key: 'value' },
-                body: { key: 'value' }
-              },
-              data: null
-            }
-          ],
-          'put'
-        )
-      ).not.toThrow(Error);
-      expect(() =>
-        validateRoutes(
-          [
-            {
-              entities: {
-                [correctEntity]: { key: 'value' },
-                body: { key: 'value' }
-              },
-              data: null
-            }
-          ],
-          'patch'
-        )
-      ).not.toThrow(Error);
-    });
-
-    const incorrectEntities = ['other'];
-    incorrectEntities.forEach((incorrectEntity) => {
-      expect(() =>
-        validateRoutes(
-          [
-            {
-              entities: {
-                [incorrectEntity]: { key: 'value' }
-              },
-              data: null
-            }
-          ],
-          'post'
-        )
-      ).toThrow(new Error(`routes[0].entities.${incorrectEntity}`));
-      expect(() =>
-        validateRoutes(
-          [
-            {
-              entities: {
-                [incorrectEntity]: { key: 'value' }
-              },
-              data: null
-            }
-          ],
-          'put'
-        )
-      ).toThrow(new Error(`routes[0].entities.${incorrectEntity}`));
-      expect(() =>
-        validateRoutes(
-          [
-            {
-              entities: {
-                [incorrectEntity]: { key: 'value' }
-              },
-              data: null
-            }
-          ],
-          'patch'
-        )
-      ).toThrow(new Error(`routes[0].entities.${incorrectEntity}`));
-    });
-  });
-
-  test('Should correctly handle body entity only with correct type', () => {
-    const correctBodyValues = [[], {}];
-    correctBodyValues.forEach((correctBodyValue) => {
-      expect(() =>
-        validateRoutes(
-          [
-            {
-              entities: { body: correctBodyValue },
-              data: null
-            }
-          ],
-          'post'
-        )
-      ).not.toThrow(Error);
-    });
-
-    const incorrectBodyValues = ['string', 3000, true, null, undefined, () => {}, /\d/];
-    incorrectBodyValues.forEach((incorrectBodyValue) => {
-      expect(() =>
-        validateRoutes(
-          [
-            {
-              entities: { body: incorrectBodyValue },
-              data: null
-            }
-          ],
-          'post'
-        )
-      ).toThrow(new Error('routes[0].entities.body'));
-    });
-
-    const correctBodyMappedValues = [{}, [], 'string', 3000, true, null];
-    correctBodyMappedValues.forEach((correctBodyMappedValue) => {
-      expect(() =>
-        validateRoutes(
-          [
-            {
-              entities: { body: { key: correctBodyMappedValue } },
-              data: null
-            }
-          ],
-          'post'
-        )
-      ).not.toThrow(Error);
-      expect(() =>
-        validateRoutes(
-          [
-            {
-              entities: { body: { key: [correctBodyMappedValue] } },
-              data: null
-            }
-          ],
-          'post'
-        )
-      ).not.toThrow(Error);
-    });
-
-    const incorrectBodyMappedValues = [undefined, () => {}, /\d/];
-    incorrectBodyMappedValues.forEach((incorrectBodyMappedValue) => {
-      expect(() =>
-        validateRoutes(
-          [
-            {
-              entities: { body: { key: incorrectBodyMappedValue } },
-              data: null
-            }
-          ],
-          'post'
-        )
-      ).toThrow(new Error('routes[0].entities.body.key'));
-      expect(() =>
-        validateRoutes(
-          [
-            {
-              entities: { body: { key: [incorrectBodyMappedValue] } },
-              data: null
-            }
-          ],
-          'post'
-        )
-      ).toThrow(new Error('routes[0].entities.body.key[0]'));
-    });
-  });
-
-  test('Should correctly handle headers entity only with correct type', () => {
-    const correctHeadersMappedValues = ['string', 3000, true];
-    correctHeadersMappedValues.forEach((correctHeadersMappedValue) => {
-      expect(() =>
-        validateRoutes(
-          [
-            {
-              entities: { headers: { key: correctHeadersMappedValue } },
-              data: null
-            }
-          ],
-          'get'
-        )
-      ).not.toThrow(Error);
-    });
-
-    const incorrectHeadersValues = [null, undefined, [], () => {}, /\d/];
-    incorrectHeadersValues.forEach((incorrectHeaderValue) => {
-      expect(() =>
-        validateRoutes(
-          [
-            {
-              entities: { headers: incorrectHeaderValue },
-              data: null
-            }
-          ],
-          'get'
-        )
-      ).toThrow(new Error('routes[0].entities.headers'));
-    });
-
-    const incorrectHeadersMappedValues = [undefined, {}, () => {}, /\d/];
-    incorrectHeadersMappedValues.forEach((incorrectHeadersMappedValue) => {
-      expect(() =>
-        validateRoutes(
-          [
-            {
-              entities: { headers: { key: incorrectHeadersMappedValue } },
-              data: null
-            }
-          ],
-          'get'
-        )
-      ).toThrow(new Error('routes[0].entities.headers.key'));
-    });
-  });
-
-  test('Should correctly handle cookies entity only with correct type', () => {
-    const correctCookiesMappedValues = ['string', 3000, true];
-    correctCookiesMappedValues.forEach((correctCookiesMappedValue) => {
-      expect(() =>
-        validateRoutes(
-          [
-            {
-              entities: { cookies: { key: correctCookiesMappedValue } },
-              data: null
-            }
-          ],
-          'get'
-        )
-      ).not.toThrow(Error);
-    });
-
-    const incorrectCookiesValues = ['string', true, 3000, null, undefined, [], () => {}, /\d/];
-    incorrectCookiesValues.forEach((incorrectCookieValue) => {
-      expect(() =>
-        validateRoutes(
-          [
-            {
-              entities: { cookies: incorrectCookieValue },
-              data: null
-            }
-          ],
-          'get'
-        )
-      ).toThrow(new Error('routes[0].entities.cookies'));
-    });
-
-    const incorrectCookiesMappedValues = [undefined, {}, () => {}, /\d/];
-    incorrectCookiesMappedValues.forEach((incorrectCookiesMappedValue) => {
-      expect(() =>
-        validateRoutes(
-          [
-            {
-              entities: { cookies: { key: incorrectCookiesMappedValue } },
-              data: null
-            }
-          ],
-          'get'
-        )
-      ).toThrow(new Error('routes[0].entities.cookies.key'));
-    });
-  });
-
-  test('Should correctly handle params entity only with correct type', () => {
-    const correctParamsMappedValues = ['string', 3000, true];
-    correctParamsMappedValues.forEach((correctParamsMappedValue) => {
-      expect(() =>
-        validateRoutes(
-          [
-            {
-              entities: { params: { key: correctParamsMappedValue } },
-              data: null
-            }
-          ],
-          'get'
-        )
-      ).not.toThrow(Error);
-    });
-
-    const incorrectParamsValues = ['string', true, 3000, null, undefined, [], () => {}, /\d/];
-    incorrectParamsValues.forEach((incorrectParamValue) => {
-      expect(() =>
-        validateRoutes(
-          [
-            {
-              entities: { params: incorrectParamValue },
-              data: null
-            }
-          ],
-          'get'
-        )
-      ).toThrow(new Error('routes[0].entities.params'));
-    });
-
-    const incorrectParamsMappedValues = [undefined, {}, () => {}, /\d/];
-    incorrectParamsMappedValues.forEach((incorrectParamsMappedValue) => {
-      expect(() =>
-        validateRoutes(
-          [
-            {
-              entities: { params: { key: incorrectParamsMappedValue } },
-              data: null
-            }
-          ],
-          'get'
-        )
-      ).toThrow(new Error('routes[0].entities.params.key'));
-    });
-  });
-
-  test('Should correctly handle query entity only with correct type', () => {
-    const correctQueryMappedValues = [
-      'string',
-      ['string1', 'string2'],
-      3000,
-      [3000, -3000],
-      true,
-      [true, false]
-    ];
-    correctQueryMappedValues.forEach((correctQueryMappedValue) => {
-      expect(() =>
-        validateRoutes(
-          [
-            {
-              entities: { query: { key: correctQueryMappedValue } },
-              data: null
-            }
-          ],
-          'get'
-        )
-      ).not.toThrow(Error);
-    });
-
-    const incorrectQueryValues = ['string', true, 3000, null, undefined, [], () => {}, /\d/];
-    incorrectQueryValues.forEach((incorrectQueryValue) => {
-      expect(() =>
-        validateRoutes(
-          [
-            {
-              entities: { query: incorrectQueryValue },
-              data: null
-            }
-          ],
-          'get'
-        )
-      ).toThrow(new Error('routes[0].entities.query'));
-    });
-
-    const incorrectQueryMappedValues = [undefined, () => {}, /\d/];
-    incorrectQueryMappedValues.forEach((incorrectQueryMappedValue) => {
-      expect(() =>
-        validateRoutes(
-          [
-            {
-              entities: { query: { key: incorrectQueryMappedValue } },
-              data: null
-            }
-          ],
-          'get'
-        )
-      ).toThrow(new Error('routes[0].entities.query.key'));
-      expect(() =>
-        validateRoutes(
-          [
-            {
-              entities: { query: { key: [incorrectQueryMappedValue] } },
-              data: null
-            }
-          ],
-          'get'
-        )
-      ).toThrow(new Error('routes[0].entities.query.key[0]'));
     });
   });
 });

--- a/bin/validateMockServerConfig/validateRestConfig/validateRoutes/validateRoutes.test.ts
+++ b/bin/validateMockServerConfig/validateRestConfig/validateRoutes/validateRoutes.test.ts
@@ -1,4 +1,8 @@
-import { CHECK_MODES, PLAIN_ENTITY_CHECK_MODES } from '@/utils/constants';
+import {
+  CHECK_MODES,
+  COMPARE_WITH_DESCRIPTOR_VALUE_CHECK_MODES,
+  PLAIN_ENTITY_CHECK_MODES
+} from '@/utils/constants';
 import type { CompareWithDescriptorValueCheckMode, RestEntityName } from '@/utils/types';
 
 import { validateRoutes } from './validateRoutes';
@@ -12,16 +16,14 @@ const generateCorrectCompareWithDescriptorMappedEntity = (
   [`${checkMode}-array`]: { checkMode, value: [true, 1, 'string'] }
 });
 
-const generateAllCorrectCompareWithExpectedValueMappedEntities = () => ({
-  ...generateCorrectCompareWithDescriptorMappedEntity('equals'),
-  ...generateCorrectCompareWithDescriptorMappedEntity('notEquals'),
-  ...generateCorrectCompareWithDescriptorMappedEntity('includes'),
-  ...generateCorrectCompareWithDescriptorMappedEntity('notIncludes'),
-  ...generateCorrectCompareWithDescriptorMappedEntity('startsWith'),
-  ...generateCorrectCompareWithDescriptorMappedEntity('notStartsWith'),
-  ...generateCorrectCompareWithDescriptorMappedEntity('endsWith'),
-  ...generateCorrectCompareWithDescriptorMappedEntity('notEndsWith')
-});
+const generateAllCorrectCompareWithExpectedValueMappedEntities = () =>
+  COMPARE_WITH_DESCRIPTOR_VALUE_CHECK_MODES.reduce(
+    (acc, checkMode) => ({
+      ...acc,
+      ...generateCorrectCompareWithDescriptorMappedEntity(checkMode)
+    }),
+    {}
+  );
 
 describe('validateRoutes (rest)', () => {
   test('Should correctly handle routes only with correct type', () => {
@@ -35,6 +37,38 @@ describe('validateRoutes (rest)', () => {
     const incorrectRouteValues = ['string', true, 3000, null, undefined, {}, [], () => {}, /\d/];
     incorrectRouteValues.forEach((incorrectRouteValue) => {
       expect(() => validateRoutes([incorrectRouteValue], 'get')).toThrow(new Error('routes[0]'));
+    });
+  });
+
+  test('Should correctly handle entities only with correct type', () => {
+    const correctEntitiesValues = [{}, undefined];
+    correctEntitiesValues.forEach((correctEntitiesValue) => {
+      expect(() =>
+        validateRoutes(
+          [
+            {
+              entities: correctEntitiesValue,
+              data: null
+            }
+          ],
+          'get'
+        )
+      ).not.toThrow(Error);
+    });
+
+    const incorrectEntitiesValues = ['string', true, 3000, null, [], () => {}, /\d/];
+    incorrectEntitiesValues.forEach((incorrectEntitiesValue) => {
+      expect(() =>
+        validateRoutes(
+          [
+            {
+              entities: incorrectEntitiesValue,
+              data: null
+            }
+          ],
+          'get'
+        )
+      ).toThrow(new Error('routes[0].entities'));
     });
   });
 

--- a/bin/validateMockServerConfig/validateRestConfig/validateRoutes/validateRoutes.test.ts
+++ b/bin/validateMockServerConfig/validateRestConfig/validateRoutes/validateRoutes.test.ts
@@ -516,7 +516,7 @@ describe('validateRoutes (rest)', () => {
     });
   });
 
-  test('Should correctly hanlde body entity only with correct type', () => {
+  test('Should correctly handle body entity only with correct type', () => {
     const correctBodyValues = [[], {}];
     correctBodyValues.forEach((correctBodyValue) => {
       expect(() =>

--- a/bin/validateMockServerConfig/validateRestConfig/validateRoutes/validateRoutes.test.ts
+++ b/bin/validateMockServerConfig/validateRestConfig/validateRoutes/validateRoutes.test.ts
@@ -516,6 +516,90 @@ describe('validateRoutes (rest)', () => {
     });
   });
 
+  test('Should correctly hanlde body entity only with correct type', () => {
+    const correctBodyValues = [[], {}];
+    correctBodyValues.forEach((correctBodyValue) => {
+      expect(() =>
+        validateRoutes(
+          [
+            {
+              entities: { body: correctBodyValue },
+              data: null
+            }
+          ],
+          'post'
+        )
+      ).not.toThrow(Error);
+    });
+
+    const incorrectBodyValues = ['string', 3000, true, null, undefined, () => {}, /\d/];
+    incorrectBodyValues.forEach((incorrectBodyValue) => {
+      expect(() =>
+        validateRoutes(
+          [
+            {
+              entities: { body: incorrectBodyValue },
+              data: null
+            }
+          ],
+          'post'
+        )
+      ).toThrow(new Error('routes[0].entities.body'));
+    });
+
+    const correctBodyMappedValues = [{}, [], 'string', 3000, true, null];
+    correctBodyMappedValues.forEach((correctBodyMappedValue) => {
+      expect(() =>
+        validateRoutes(
+          [
+            {
+              entities: { body: { key: correctBodyMappedValue } },
+              data: null
+            }
+          ],
+          'post'
+        )
+      ).not.toThrow(Error);
+      expect(() =>
+        validateRoutes(
+          [
+            {
+              entities: { body: { key: [correctBodyMappedValue] } },
+              data: null
+            }
+          ],
+          'post'
+        )
+      ).not.toThrow(Error);
+    });
+
+    const incorrectBodyMappedValues = [undefined, () => {}, /\d/];
+    incorrectBodyMappedValues.forEach((incorrectBodyMappedValue) => {
+      expect(() =>
+        validateRoutes(
+          [
+            {
+              entities: { body: { key: incorrectBodyMappedValue } },
+              data: null
+            }
+          ],
+          'post'
+        )
+      ).toThrow(new Error('routes[0].entities.body.key'));
+      expect(() =>
+        validateRoutes(
+          [
+            {
+              entities: { body: { key: [incorrectBodyMappedValue] } },
+              data: null
+            }
+          ],
+          'post'
+        )
+      ).toThrow(new Error('routes[0].entities.body.key[0]'));
+    });
+  });
+
   test('Should correctly handle headers entity only with correct type', () => {
     const correctHeadersMappedValues = ['string', 3000, true];
     correctHeadersMappedValues.forEach((correctHeadersMappedValue) => {

--- a/bin/validateMockServerConfig/validateRestConfig/validateRoutes/validateRoutes.test.ts
+++ b/bin/validateMockServerConfig/validateRestConfig/validateRoutes/validateRoutes.test.ts
@@ -26,13 +26,21 @@ const generateAllCorrectCompareWithExpectedValueMappedEntities = () =>
   );
 
 describe('validateRoutes (rest)', () => {
-  describe('validateRoutes (rest): validate routes and entites types', () => {
+  describe('validateRoutes (rest): validate routes and entities types', () => {
     test('Should correctly handle routes only with correct type', () => {
-      expect(() => validateRoutes([{ data: null }], 'get')).not.toThrow(Error);
+      const correctRoutesValues = [[]];
+      correctRoutesValues.forEach((correctRouteValue) => {
+        expect(() => validateRoutes(correctRouteValue, 'get')).not.toThrow(Error);
+      });
 
       const incorrectRoutesValues = ['string', true, 3000, null, undefined, {}, () => {}, /\d/];
       incorrectRoutesValues.forEach((incorrectRoutesValue) => {
         expect(() => validateRoutes(incorrectRoutesValue, 'get')).toThrow(new Error('routes'));
+      });
+
+      const correctRouteElementValues = [{ data: null }];
+      correctRouteElementValues.forEach((correctRouteElementValue) => {
+        expect(() => validateRoutes([correctRouteElementValue], 'get')).not.toThrow(Error);
       });
 
       const incorrectRouteElementValues = [
@@ -85,7 +93,7 @@ describe('validateRoutes (rest)', () => {
       });
     });
 
-    test('Should correctly handle get|delete|options method (methods without body) entities only with correct type', () => {
+    test('Should correctly handle get|delete|options method (methods without body) only with correct entities', () => {
       const methods = ['get', 'delete', 'options'] as const;
       const correctEntities = ['headers', 'cookies', 'params', 'query'];
       const incorrectEntities = ['body', 'other'];
@@ -120,7 +128,7 @@ describe('validateRoutes (rest)', () => {
       });
     });
 
-    test('Should correctly handle post|put|patch method (methods with body) entities only with correct type', () => {
+    test('Should correctly handle post|put|patch method (methods with body) only with correct entities', () => {
       const methods = ['post', 'put', 'patch'] as const;
       const correctEntities = ['headers', 'cookies', 'params', 'query', 'body'];
       const incorrectEntities = ['other'];
@@ -366,68 +374,53 @@ describe('validateRoutes (rest)', () => {
     });
   });
 
-  test('Should correctly handle entities only with correct type', () => {
-    const correctMappedEntity = {
-      exists: { checkMode: 'exists' },
+  describe('validateRoutes(rest): entity descriptors', () => {
+    test('Should correctly handle entities only with correct type', () => {
+      const correctMappedEntity = {
+        exists: { checkMode: 'exists' },
 
-      notExists: { checkMode: 'notExists' },
+        notExists: { checkMode: 'notExists' },
 
-      'equals-plain-boolean': true,
-      'equals-plain-number': 1,
-      'equals-plain-string': 'string',
-      'equals-plain-array': [true, 1, 'string'],
-      ...generateAllCorrectCompareWithExpectedValueMappedEntities(),
+        'equals-plain-boolean': true,
+        'equals-plain-number': 1,
+        'equals-plain-string': 'string',
+        'equals-plain-array': [true, 1, 'string'],
+        ...generateAllCorrectCompareWithExpectedValueMappedEntities(),
 
-      'regExp-value': { checkMode: 'regExp', value: /^regExp/ },
-      'regExp-array': { checkMode: 'regExp', value: [/^regExp1$/, /^regExp2$/] },
+        'regExp-value': { checkMode: 'regExp', value: /^regExp/ },
+        'regExp-array': { checkMode: 'regExp', value: [/^regExp1$/, /^regExp2$/] },
 
-      function: {
-        checkMode: 'function',
-        value: (actualValue: string) => actualValue === 'actualValue'
-      }
-    };
+        function: {
+          checkMode: 'function',
+          value: (actualValue: string) => actualValue === 'actualValue'
+        }
+      };
 
-    const correctMappedEntitiesValues = [
-      {},
-      {
-        headers: correctMappedEntity,
-        cookies: correctMappedEntity,
-        params: correctMappedEntity,
-        query: correctMappedEntity
-      },
-      undefined
-    ];
-    correctMappedEntitiesValues.forEach((correctMappedEntitiesValue) => {
-      expect(() =>
-        validateRoutes(
-          [
-            {
-              entities: correctMappedEntitiesValue,
-              data: null
-            }
-          ],
-          'get'
-        )
-      ).not.toThrow(Error);
+      const correctMappedEntitiesValues = [
+        {},
+        {
+          headers: correctMappedEntity,
+          cookies: correctMappedEntity,
+          params: correctMappedEntity,
+          query: correctMappedEntity
+        },
+        undefined
+      ];
+      correctMappedEntitiesValues.forEach((correctMappedEntitiesValue) => {
+        expect(() =>
+          validateRoutes(
+            [
+              {
+                entities: correctMappedEntitiesValue,
+                data: null
+              }
+            ],
+            'get'
+          )
+        ).not.toThrow(Error);
+      });
     });
 
-    const incorrectEntitiesValues = ['string', true, 3000, null, [], () => {}, /\d/];
-    incorrectEntitiesValues.forEach((incorrectEntitiesValue) => {
-      expect(() =>
-        validateRoutes(
-          [
-            {
-              entities: incorrectEntitiesValue,
-              data: null
-            }
-          ],
-          'get'
-        )
-      ).toThrow(new Error('routes[0].entities'));
-    });
-  });
-
-  describe('Entity descriptors', () => {
     test('Should allow only correct descriptor checkModes for mapped entities', () => {
       const MAPPED_ENTITY_NAMES: Exclude<RestEntityName, 'body'>[] = [
         'headers',

--- a/bin/validateMockServerConfig/validateRestConfig/validateRoutes/validateRoutes.test.ts
+++ b/bin/validateMockServerConfig/validateRestConfig/validateRoutes/validateRoutes.test.ts
@@ -7,7 +7,7 @@ import type { CompareWithDescriptorValueCheckMode, RestEntityName } from '@/util
 
 import { validateRoutes } from './validateRoutes';
 
-const generateCorrectCompareWithDescriptorMappedEntity = (
+const generateCorrectCompareWithDescriptorValueMappedEntity = (
   checkMode: CompareWithDescriptorValueCheckMode
 ) => ({
   [`${checkMode}-boolean`]: { checkMode, value: true },
@@ -20,7 +20,7 @@ const generateAllCorrectCompareWithExpectedValueMappedEntities = () =>
   COMPARE_WITH_DESCRIPTOR_VALUE_CHECK_MODES.reduce(
     (acc, checkMode) => ({
       ...acc,
-      ...generateCorrectCompareWithDescriptorMappedEntity(checkMode)
+      ...generateCorrectCompareWithDescriptorValueMappedEntity(checkMode)
     }),
     {}
   );
@@ -186,13 +186,13 @@ describe('validateRoutes (rest)', () => {
         ).toThrow(new Error('routes[0].entities.body'));
       });
 
-      const correctBodyPropertyValues = [{}, [], 'string', 3000, true, null];
-      correctBodyPropertyValues.forEach((correctBodyPropertyValue) => {
+      const correctBodyObjectPropertyValues = [{}, [], 'string', 3000, true, null];
+      correctBodyObjectPropertyValues.forEach((correctBodyObjectPropertyValue) => {
         expect(() =>
           validateRoutes(
             [
               {
-                entities: { body: { key: correctBodyPropertyValue } },
+                entities: { body: { key: correctBodyObjectPropertyValue } },
                 data: null
               }
             ],
@@ -203,18 +203,7 @@ describe('validateRoutes (rest)', () => {
           validateRoutes(
             [
               {
-                entities: { body: { key: [correctBodyPropertyValue] } },
-                data: null
-              }
-            ],
-            'post'
-          )
-        ).not.toThrow(Error);
-        expect(() =>
-          validateRoutes(
-            [
-              {
-                entities: { body: [correctBodyPropertyValue] },
+                entities: { body: { key: [correctBodyObjectPropertyValue] } },
                 data: null
               }
             ],
@@ -223,13 +212,13 @@ describe('validateRoutes (rest)', () => {
         ).not.toThrow(Error);
       });
 
-      const incorrectBodyPropertyValues = [undefined, () => {}, /\d/];
-      incorrectBodyPropertyValues.forEach((incorrectBodyPropertyValue) => {
+      const incorrectBodyObjectPropertyValues = [undefined, () => {}, /\d/];
+      incorrectBodyObjectPropertyValues.forEach((incorrectBodyObjectPropertyValue) => {
         expect(() =>
           validateRoutes(
             [
               {
-                entities: { body: { key: incorrectBodyPropertyValue } },
+                entities: { body: { key: incorrectBodyObjectPropertyValue } },
                 data: null
               }
             ],
@@ -240,18 +229,45 @@ describe('validateRoutes (rest)', () => {
           validateRoutes(
             [
               {
-                entities: { body: { key: [incorrectBodyPropertyValue] } },
+                entities: { body: { key: [incorrectBodyObjectPropertyValue] } },
                 data: null
               }
             ],
             'post'
           )
         ).toThrow(new Error('routes[0].entities.body.key[0]'));
+      });
+
+      const correctBodyArrayPropertyValues = [{}, []];
+      correctBodyArrayPropertyValues.forEach((correctBodyArrayPropertyValue) => {
         expect(() =>
           validateRoutes(
             [
               {
-                entities: { body: [incorrectBodyPropertyValue] },
+                entities: { body: [correctBodyArrayPropertyValue] },
+                data: null
+              }
+            ],
+            'post'
+          )
+        ).not.toThrow(Error);
+      });
+
+      const incorrectBodyArrayPropertyValues = [
+        'string',
+        3000,
+        true,
+        null,
+        undefined,
+        () => {},
+        /\d/
+      ];
+      incorrectBodyArrayPropertyValues.forEach((incorrectBodyArrayPropertyValue) => {
+        expect(() =>
+          validateRoutes(
+            [
+              {
+                entities: { body: [incorrectBodyArrayPropertyValue] },
                 data: null
               }
             ],

--- a/bin/validateMockServerConfig/validateRestConfig/validateRoutes/validateRoutes.test.ts
+++ b/bin/validateMockServerConfig/validateRestConfig/validateRoutes/validateRoutes.test.ts
@@ -217,7 +217,7 @@ describe('validateRoutes (rest)', () => {
         ).toThrow(new Error('routes[0].entities.headers.key.value'));
       });
 
-      const incorrectMappedEntityValues = [null, {}, () => {}, /\d/];
+      const incorrectMappedEntityValues = [undefined, {}, () => {}, /\d/];
       incorrectMappedEntityValues.forEach((incorrectMappedEntityValue) => {
         expect(() =>
           validateRoutes(
@@ -547,7 +547,7 @@ describe('validateRoutes (rest)', () => {
       ).toThrow(new Error('routes[0].entities.headers'));
     });
 
-    const incorrectHeadersMappedValues = [null, undefined, {}, () => {}, /\d/];
+    const incorrectHeadersMappedValues = [undefined, {}, () => {}, /\d/];
     incorrectHeadersMappedValues.forEach((incorrectHeadersMappedValue) => {
       expect(() =>
         validateRoutes(
@@ -594,7 +594,7 @@ describe('validateRoutes (rest)', () => {
       ).toThrow(new Error('routes[0].entities.cookies'));
     });
 
-    const incorrectCookiesMappedValues = [null, undefined, {}, () => {}, /\d/];
+    const incorrectCookiesMappedValues = [undefined, {}, () => {}, /\d/];
     incorrectCookiesMappedValues.forEach((incorrectCookiesMappedValue) => {
       expect(() =>
         validateRoutes(
@@ -641,7 +641,7 @@ describe('validateRoutes (rest)', () => {
       ).toThrow(new Error('routes[0].entities.params'));
     });
 
-    const incorrectParamsMappedValues = [null, undefined, {}, () => {}, /\d/];
+    const incorrectParamsMappedValues = [undefined, {}, () => {}, /\d/];
     incorrectParamsMappedValues.forEach((incorrectParamsMappedValue) => {
       expect(() =>
         validateRoutes(
@@ -695,7 +695,7 @@ describe('validateRoutes (rest)', () => {
       ).toThrow(new Error('routes[0].entities.query'));
     });
 
-    const incorrectQueryMappedValues = [null, undefined, () => {}, /\d/];
+    const incorrectQueryMappedValues = [undefined, () => {}, /\d/];
     incorrectQueryMappedValues.forEach((incorrectQueryMappedValue) => {
       expect(() =>
         validateRoutes(

--- a/bin/validateMockServerConfig/validateRestConfig/validateRoutes/validateRoutes.ts
+++ b/bin/validateMockServerConfig/validateRestConfig/validateRoutes/validateRoutes.ts
@@ -24,7 +24,12 @@ const validateEntity = (entity: unknown, entityName: RestEntityName) => {
       throw new Error('body.checkMode');
     }
 
-    if (!isDescriptorValueValid(entity.checkMode, entity.value, true)) {
+    const isDescriptorValueObjectOrArray =
+      isPlainObject(entity.value) || Array.isArray(entity.value);
+    if (
+      !isDescriptorValueObjectOrArray ||
+      !isDescriptorValueValid(entity.checkMode, entity.value)
+    ) {
       throw new Error('body.value');
     }
   }
@@ -44,28 +49,26 @@ const validateEntity = (entity: unknown, entityName: RestEntityName) => {
       const isValueArray = Array.isArray(value);
       if (isValueArray) {
         value.forEach((element, index) => {
-          if (
-            isBody &&
-            !isDescriptorValueValid(checkMode, element, true) &&
-            !isDescriptorValueValid(checkMode, element, false)
-          ) {
+          if (isBody) {
+            if (isDescriptorValueValid(checkMode, element)) return;
             throw new Error(`${errorMessage}[${index}]`);
           }
-          if (!isBody && !isDescriptorValueValid(checkMode, element, false)) {
+
+          const isElementObjectOrArray = isPlainObject(element) || Array.isArray(element);
+          if (isElementObjectOrArray || !isDescriptorValueValid(checkMode, element)) {
             throw new Error(`${errorMessage}[${index}]`);
           }
         });
         return;
       }
 
-      if (
-        isBody &&
-        !isDescriptorValueValid(checkMode, value, true) &&
-        !isDescriptorValueValid(checkMode, value, false)
-      ) {
+      if (isBody) {
+        if (isDescriptorValueValid(checkMode, value)) return;
         throw new Error(errorMessage);
       }
-      if (!isBody && !isDescriptorValueValid(checkMode, value, false)) {
+
+      const isValueObjectOrArray = isPlainObject(value) || Array.isArray(value);
+      if (isValueObjectOrArray || !isDescriptorValueValid(checkMode, value)) {
         throw new Error(errorMessage);
       }
     });

--- a/bin/validateMockServerConfig/validateRestConfig/validateRoutes/validateRoutes.ts
+++ b/bin/validateMockServerConfig/validateRestConfig/validateRoutes/validateRoutes.ts
@@ -50,7 +50,8 @@ const validateEntity = (entity: unknown, entityName: RestEntityName) => {
             !isDescriptorValueValid(checkMode, element, false)
           ) {
             throw new Error(`${errorMessage}[${index}]`);
-          } else if (!isDescriptorValueValid(checkMode, element, false)) {
+          }
+          if (!isBody && !isDescriptorValueValid(checkMode, element, false)) {
             throw new Error(`${errorMessage}[${index}]`);
           }
         });
@@ -63,7 +64,8 @@ const validateEntity = (entity: unknown, entityName: RestEntityName) => {
         !isDescriptorValueValid(checkMode, value, false)
       ) {
         throw new Error(errorMessage);
-      } else if (!isDescriptorValueValid(checkMode, value, false)) {
+      }
+      if (!isBody && !isDescriptorValueValid(checkMode, value, false)) {
         throw new Error(errorMessage);
       }
     });

--- a/bin/validateMockServerConfig/validateRestConfig/validateRoutes/validateRoutes.ts
+++ b/bin/validateMockServerConfig/validateRestConfig/validateRoutes/validateRoutes.ts
@@ -42,7 +42,7 @@ const validateEntity = (entity: unknown, entityName: RestEntityName) => {
       const errorMessage = `${entityName}.${key}${isDescriptor ? '.value' : ''}`;
 
       const isValueArray = Array.isArray(value);
-      if (isValueArray && !isBody) {
+      if (isValueArray) {
         value.forEach((element, index) => {
           if (
             isBody &&

--- a/bin/validateMockServerConfig/validateRestConfig/validateRoutes/validateRoutes.ts
+++ b/bin/validateMockServerConfig/validateRestConfig/validateRoutes/validateRoutes.ts
@@ -26,7 +26,7 @@ const validateEntity = (entity: unknown, entityName: string) => {
       throw new Error('body.checkMode');
     }
 
-    if (!isDescriptorValueValid(topLevelCheckMode, topLevelValue, 'body')) {
+    if (!isDescriptorValueValid(topLevelCheckMode, topLevelValue, true)) {
       const errorMessage = 'body.value';
       throw new Error(errorMessage);
     }
@@ -47,13 +47,13 @@ const validateEntity = (entity: unknown, entityName: string) => {
       const isValueArray = Array.isArray(value);
       if (isValueArray && !isBody) {
         value.forEach((element, index) => {
-          if (!isDescriptorValueValid(checkMode, element)) {
+          if (!isDescriptorValueValid(checkMode, element, false)) {
             throw new Error(`${errorMessage}[${index}]`);
           }
         });
         return;
       }
-      if (!isDescriptorValueValid(checkMode, value)) {
+      if (!isDescriptorValueValid(checkMode, value, false)) {
         throw new Error(errorMessage);
       }
     });

--- a/bin/validateMockServerConfig/validateRestConfig/validateRoutes/validateRoutes.ts
+++ b/bin/validateMockServerConfig/validateRestConfig/validateRoutes/validateRoutes.ts
@@ -7,6 +7,7 @@ import { validateInterceptors } from '../../validateInterceptors/validateInterce
 type AllowedEntityNamesByMethod = {
   [Method in keyof RestEntityNamesByMethod]: RestEntityNamesByMethod[Method][];
 };
+
 const ALLOWED_ENTITIES_BY_METHOD: AllowedEntityNamesByMethod = {
   get: ['headers', 'cookies', 'query', 'params'],
   delete: ['headers', 'cookies', 'query', 'params'],
@@ -29,7 +30,12 @@ const validateEntity = (entity: unknown, entityName: RestEntityName) => {
       throw new Error('body.checkMode');
     }
 
-    if (!isDescriptorValueValid(entity.checkMode, entity.value)) {
+    const isDescriptorValueObjectOrArray =
+      isPlainObject(entity.value) || Array.isArray(entity.value);
+    if (
+      !isDescriptorValueObjectOrArray ||
+      !isDescriptorValueValid(entity.checkMode, entity.value)
+    ) {
       throw new Error('body.value');
     }
 
@@ -43,8 +49,10 @@ const validateEntity = (entity: unknown, entityName: RestEntityName) => {
     }
 
     entity.forEach((entityElement, index) => {
-      if (!isDescriptorValueValid('equals', entityElement)) {
-        throw new Error(`body[${index}]`);
+      const isEntityElementObjectOrArray =
+        isPlainObject(entityElement) || Array.isArray(entityElement);
+      if (!isEntityElementObjectOrArray || !isDescriptorValueValid('equals', entityElement)) {
+        throw new Error(`${entityName}[${index}]`);
       }
     });
 
@@ -83,9 +91,8 @@ const validateEntity = (entity: unknown, entityName: RestEntityName) => {
         throw new Error(errorMessage);
       }
 
-      // FIXME useless array checking
-      const isValueObjectOrArray = isPlainObject(value) || Array.isArray(value);
-      if (isValueObjectOrArray || !isDescriptorValueValid(checkMode, value)) {
+      const isValueObject = isPlainObject(value);
+      if (isValueObject || !isDescriptorValueValid(checkMode, value)) {
         throw new Error(errorMessage);
       }
     });

--- a/bin/validateMockServerConfig/validateRestConfig/validateRoutes/validateRoutes.ts
+++ b/bin/validateMockServerConfig/validateRestConfig/validateRoutes/validateRoutes.ts
@@ -83,6 +83,7 @@ const validateEntity = (entity: unknown, entityName: RestEntityName) => {
         throw new Error(errorMessage);
       }
 
+      // FIXME useless array checking
       const isValueObjectOrArray = isPlainObject(value) || Array.isArray(value);
       if (isValueObjectOrArray || !isDescriptorValueValid(checkMode, value)) {
         throw new Error(errorMessage);

--- a/src/core/graphql/createGraphQLRoutes/createGraphQLRoutes.test.ts
+++ b/src/core/graphql/createGraphQLRoutes/createGraphQLRoutes.test.ts
@@ -94,40 +94,7 @@ describe('createGraphQLRoutes', () => {
       });
     });
 
-    test('Should return 400 and description text if operationName does not presented in graphql query', async () => {
-      const server = createServer({
-        graphql: {
-          configs: [
-            {
-              operationName: 'GetUsers',
-              operationType: 'query',
-              routes: [
-                {
-                  data: { name: 'John', surname: 'Doe' }
-                }
-              ]
-            }
-          ]
-        }
-      });
-
-      const postResponse = await request(server)
-        .post('/')
-        .send({ query: 'query { users { name } }' });
-      expect(postResponse.statusCode).toBe(400);
-      expect(postResponse.body).toStrictEqual({
-        message: 'You should to specify operationName for POST:/'
-      });
-
-      const getResponse = await request(server)
-        .get('/')
-        .query({ query: 'query { users { name } }' });
-      expect(getResponse.statusCode).toBe(400);
-      expect(getResponse.body).toStrictEqual({
-        message: 'You should to specify operationName for GET:/'
-      });
-    });
-
+    // TODO delete
     test('Should return 404 for no matched request configs', async () => {
       const server = createServer({
         graphql: {
@@ -159,6 +126,149 @@ describe('createGraphQLRoutes', () => {
       const getResponse = await request(server)
         .get('/')
         .set({ key2: 'value2' })
+        .query({ query: 'query GetUsers { users { name } }' });
+      expect(getResponse.statusCode).toBe(404);
+    });
+  });
+
+  describe('createGraphQLRoutes: not found config', () => {
+    test('Should return 404 for not matched operationType', async () => {
+      const server = createServer({
+        graphql: {
+          configs: [
+            {
+              operationName: 'GetUsers',
+              operationType: 'query',
+              routes: [
+                {
+                  data: { name: 'John', surname: 'Doe' }
+                }
+              ]
+            }
+          ]
+        }
+      });
+
+      const postResponse = await request(server)
+        .post('/')
+        .send({ query: 'mutation GetUsers { users { name } }' });
+      expect(postResponse.statusCode).toBe(404);
+
+      const getResponse = await request(server)
+        .get('/')
+        .query({ query: 'mutation GetUsers { users { name } }' });
+      expect(getResponse.statusCode).toBe(404);
+    });
+
+    test('Should return 404 for not matched query', async () => {
+      const server = createServer({
+        graphql: {
+          configs: [
+            {
+              operationName: 'GetUsers',
+              operationType: 'query',
+              query: 'mutation GetUsers { users { name } }',
+              routes: [
+                {
+                  data: { name: 'John', surname: 'Doe' }
+                }
+              ]
+            }
+          ]
+        }
+      });
+
+      const postResponse = await request(server)
+        .post('/')
+        .send({ query: 'query GetUsers { users { name } }' });
+      expect(postResponse.statusCode).toBe(404);
+
+      const getResponse = await request(server)
+        .get('/')
+        .query({ query: 'query GetUsers { users { name } }' });
+      expect(getResponse.statusCode).toBe(404);
+    });
+
+    test('Should return 404 if operationName presented in config but not presented in actual query', async () => {
+      const server = createServer({
+        graphql: {
+          configs: [
+            {
+              operationName: 'GetUsers',
+              operationType: 'query',
+              routes: [
+                {
+                  data: { name: 'John', surname: 'Doe' }
+                }
+              ]
+            }
+          ]
+        }
+      });
+
+      const postResponse = await request(server)
+        .post('/')
+        .send({ query: 'query { users { name } }' });
+      expect(postResponse.statusCode).toBe(404);
+
+      const getResponse = await request(server)
+        .get('/')
+        .query({ query: 'query { users { name } }' });
+      expect(getResponse.statusCode).toBe(404);
+    });
+
+    test('Should return 404 if actual query operationName does not match to config RegExp operationName', async () => {
+      const server = createServer({
+        graphql: {
+          configs: [
+            {
+              operationName: /GetUsers\d+/,
+              operationType: 'query',
+              routes: [
+                {
+                  data: { name: 'John', surname: 'Doe' }
+                }
+              ]
+            }
+          ]
+        }
+      });
+
+      const postResponse = await request(server)
+        .post('/')
+        .send({ query: 'query GetUsers { users { name } }' });
+      expect(postResponse.statusCode).toBe(404);
+
+      const getResponse = await request(server)
+        .get('/')
+        .query({ query: 'query GetUsers { users { name } }' });
+      expect(getResponse.statusCode).toBe(404);
+    });
+
+    test('Should return 404 if actual query operationName does not mathc to config string operationName', async () => {
+      const server = createServer({
+        graphql: {
+          configs: [
+            {
+              operationName: 'GetSettings',
+              operationType: 'query',
+              routes: [
+                {
+                  data: { name: 'John', surname: 'Doe' }
+                }
+              ]
+            }
+          ]
+        }
+      });
+
+      const postResponse = await request(server)
+        .post('/')
+        .send({ query: 'query GetUsers { users { name } }' });
+      expect(postResponse.statusCode).toBe(404);
+
+      const getResponse = await request(server)
+        .get('/')
         .query({ query: 'query GetUsers { users { name } }' });
       expect(getResponse.statusCode).toBe(404);
     });

--- a/src/core/graphql/createGraphQLRoutes/createGraphQLRoutes.test.ts
+++ b/src/core/graphql/createGraphQLRoutes/createGraphQLRoutes.test.ts
@@ -209,7 +209,7 @@ describe('createGraphQLRoutes', () => {
       expect(getResponse.statusCode).toBe(404);
     });
 
-    test('Should return 404 if actual query operationName does not mathc to config string operationName', async () => {
+    test('Should return 404 if actual query operationName does not match to config string operationName', async () => {
       const server = createServer({
         graphql: {
           configs: [

--- a/src/core/graphql/createGraphQLRoutes/createGraphQLRoutes.test.ts
+++ b/src/core/graphql/createGraphQLRoutes/createGraphQLRoutes.test.ts
@@ -93,42 +93,6 @@ describe('createGraphQLRoutes', () => {
         message: 'Query is invalid, you must use a valid GraphQL query'
       });
     });
-
-    // TODO delete
-    test('Should return 404 for no matched request configs', async () => {
-      const server = createServer({
-        graphql: {
-          configs: [
-            {
-              operationName: 'GetUsers',
-              operationType: 'query',
-              routes: [
-                {
-                  entities: {
-                    headers: {
-                      key1: 'value1'
-                    }
-                  },
-                  data: { name: 'John', surname: 'Doe' }
-                }
-              ]
-            }
-          ]
-        }
-      });
-
-      const postResponse = await request(server)
-        .post('/')
-        .send({ query: 'query GetUsers { users { name } }' })
-        .set({ key2: 'value2' });
-      expect(postResponse.statusCode).toBe(404);
-
-      const getResponse = await request(server)
-        .get('/')
-        .set({ key2: 'value2' })
-        .query({ query: 'query GetUsers { users { name } }' });
-      expect(getResponse.statusCode).toBe(404);
-    });
   });
 
   describe('createGraphQLRoutes: not found config', () => {
@@ -269,6 +233,41 @@ describe('createGraphQLRoutes', () => {
 
       const getResponse = await request(server)
         .get('/')
+        .query({ query: 'query GetUsers { users { name } }' });
+      expect(getResponse.statusCode).toBe(404);
+    });
+
+    test('Should return 404 for no matched by entities request configs', async () => {
+      const server = createServer({
+        graphql: {
+          configs: [
+            {
+              operationName: 'GetUsers',
+              operationType: 'query',
+              routes: [
+                {
+                  entities: {
+                    headers: {
+                      key1: 'value1'
+                    }
+                  },
+                  data: { name: 'John', surname: 'Doe' }
+                }
+              ]
+            }
+          ]
+        }
+      });
+
+      const postResponse = await request(server)
+        .post('/')
+        .send({ query: 'query GetUsers { users { name } }' })
+        .set({ key2: 'value2' });
+      expect(postResponse.statusCode).toBe(404);
+
+      const getResponse = await request(server)
+        .get('/')
+        .set({ key2: 'value2' })
         .query({ query: 'query GetUsers { users { name } }' });
       expect(getResponse.statusCode).toBe(404);
     });

--- a/src/core/graphql/createGraphQLRoutes/createGraphQLRoutes.test.ts
+++ b/src/core/graphql/createGraphQLRoutes/createGraphQLRoutes.test.ts
@@ -428,7 +428,7 @@ describe('createGraphQLRoutes', () => {
   });
 
   describe('createGraphQLRoutes: interceptors', () => {
-    test('Should call request interceptor for specific route', async () => {
+    test('Should call request interceptor for specific config', async () => {
       const requestInterceptor = jest.fn();
       const server = createServer({
         graphql: {
@@ -578,7 +578,7 @@ describe('createGraphQLRoutes', () => {
   });
 
   describe('createGraphQLRoutes: browsers specific', () => {
-    test('Should have response Cache-Control header equals to max-age=0, must-revalidate', async () => {
+    test('Should have response Cache-Control header with max-age=0, must-revalidate value', async () => {
       const server = createServer({
         graphql: {
           configs: [

--- a/src/core/graphql/createGraphQLRoutes/createGraphQLRoutes.test.ts
+++ b/src/core/graphql/createGraphQLRoutes/createGraphQLRoutes.test.ts
@@ -319,7 +319,7 @@ describe('createGraphQLRoutes', () => {
                     checkMode: 'equals',
                     value: {
                       key1: 'value1',
-                      key2: { nestedKey1: 'nestedValue1' }
+                      'key2.nestedKey1': 'nestedValue1'
                     }
                   }
                 },

--- a/src/core/graphql/createGraphQLRoutes/createGraphQLRoutes.test.ts
+++ b/src/core/graphql/createGraphQLRoutes/createGraphQLRoutes.test.ts
@@ -374,6 +374,46 @@ describe('createGraphQLRoutes', () => {
     });
   });
 
+  describe('createGraphQLRoutes: top level array variables', () => {
+    test('Should iterate over top level array variables and compare with each element', async () => {
+      const server = createServer({
+        graphql: {
+          configs: [
+            {
+              operationName: 'GetUsers',
+              operationType: 'query',
+              routes: [
+                {
+                  entities: {
+                    variables: [{ key1: 'value1' }, { key1: 'value1', key2: 'value2' }]
+                  },
+                  data: { name: 'John', surname: 'Doe' }
+                }
+              ]
+            }
+          ]
+        }
+      });
+
+      const successResponse = await request(server)
+        .get('/')
+        .query({
+          query: 'query GetUsers { users { name } }',
+          variables: { key1: 'value1', key2: 'value2' }
+        });
+      expect(successResponse.statusCode).toBe(200);
+      expect(successResponse.body).toStrictEqual({ name: 'John', surname: 'Doe' });
+
+      const notFoundResponse = await request(server)
+        .get('/')
+        .query({
+          query: 'query GetUsers { users { name } }',
+          variables: { key1: 'value1', key2: 'value2', key3: 'value3' }
+        });
+      expect(notFoundResponse.statusCode).toBe(404);
+    });
+  });
+
   describe('createGraphQLRoutes: descriptors', () => {
     test('Should correctly resolve flat object variables with descriptors', async () => {
       const server = createServer({

--- a/src/core/graphql/createGraphQLRoutes/createGraphQLRoutes.ts
+++ b/src/core/graphql/createGraphQLRoutes/createGraphQLRoutes.ts
@@ -85,8 +85,16 @@ export const createGraphQLRoutes = (
           return resolveEntityValues(checkMode, graphQLInput.variables, entityDescriptorValue);
         }
 
+        const isEntityVariablesByTopLevelArray =
+          entityName === 'variables' && Array.isArray(entityDescriptorOrValue);
+        if (isEntityVariablesByTopLevelArray) {
+          return entityDescriptorOrValue.some((entityDescriptorOrValueElement) =>
+            resolveEntityValues(checkMode, graphQLInput.variables, entityDescriptorOrValueElement)
+          );
+        }
+
         const recordOrArrayEntries = Object.entries(entityDescriptorOrValue) as Entries<
-          Exclude<GraphQLEntityDescriptorOrValue, GraphQLTopLevelPlainEntityDescriptor>
+          Exclude<GraphQLEntityDescriptorOrValue, GraphQLTopLevelPlainEntityDescriptor | Array<any>>
         >;
         return recordOrArrayEntries.every(([entityKey, entityValue]) => {
           const { checkMode, value: descriptorValue } = convertToEntityDescriptor(entityValue);

--- a/src/core/graphql/createGraphQLRoutes/createGraphQLRoutes.ts
+++ b/src/core/graphql/createGraphQLRoutes/createGraphQLRoutes.ts
@@ -45,22 +45,15 @@ export const createGraphQLRoutes = (
     }
 
     const matchedRequestConfig = preparedGraphQLRequestConfig.find((requestConfig) => {
-      if (requestConfig.operationType !== query.operationType) {
-        return false;
-      }
+      if (requestConfig.operationType !== query.operationType) return false;
 
-      if ('query' in requestConfig && requestConfig.query !== graphQLInput.query) {
-        return false;
-      }
+      if ('query' in requestConfig && requestConfig.query !== graphQLInput.query) return false;
 
       if ('operationName' in requestConfig) {
-        if (!query.operationName) {
-          return false;
-        }
+        if (!query.operationName) return false;
 
-        if (requestConfig.operationName instanceof RegExp) {
+        if (requestConfig.operationName instanceof RegExp)
           return new RegExp(requestConfig.operationName).test(query.operationName);
-        }
 
         return requestConfig.operationName === query.operationName;
       }
@@ -98,7 +91,7 @@ export const createGraphQLRoutes = (
         return recordOrArrayEntries.every(([entityKey, entityValue]) => {
           const { checkMode, value: descriptorValue } = convertToEntityDescriptor(entityValue);
           const flattenEntity = flatten<any, any>(
-            entityName === 'variables' ? graphQLInput.variables ?? {} : request[entityName]
+            entityName === 'variables' ? graphQLInput.variables : request[entityName]
           );
 
           // ✅ important: transform header keys to lower case because browsers send headers in lowercase

--- a/src/core/graphql/createGraphQLRoutes/createGraphQLRoutes.ts
+++ b/src/core/graphql/createGraphQLRoutes/createGraphQLRoutes.ts
@@ -105,9 +105,7 @@ export const createGraphQLRoutes = (
           // ✅ important: transform header keys to lower case because browsers send headers in lowercase
           return resolveEntityValues(
             checkMode,
-            flattenEntity[
-              entityName === 'headers' ? (entityKey as string).toLowerCase() : entityKey
-            ],
+            flattenEntity[entityName === 'headers' ? entityKey.toLowerCase() : entityKey],
             descriptorValue
           );
         });

--- a/src/core/graphql/createGraphQLRoutes/createGraphQLRoutes.ts
+++ b/src/core/graphql/createGraphQLRoutes/createGraphQLRoutes.ts
@@ -47,7 +47,11 @@ export const createGraphQLRoutes = (
     const matchedRequestConfig = preparedGraphQLRequestConfig.find((requestConfig) => {
       if (requestConfig.operationType !== query.operationType) return false;
 
-      if ('query' in requestConfig && requestConfig.query !== graphQLInput.query) return false;
+      if (
+        'query' in requestConfig &&
+        requestConfig.query.replace(/\s+/gi, ' ') !== graphQLInput.query?.replace(/\s+/gi, ' ')
+      )
+        return false;
 
       if ('operationName' in requestConfig) {
         if (!query.operationName) return false;

--- a/src/core/graphql/createGraphQLRoutes/createGraphQLRoutes.ts
+++ b/src/core/graphql/createGraphQLRoutes/createGraphQLRoutes.ts
@@ -31,7 +31,7 @@ export const createGraphQLRoutes = (
 
   const graphqlMiddleware = async (request: Request, response: Response, next: NextFunction) => {
     const graphQLInput = getGraphQLInput(request);
-    if (!graphQLInput || !graphQLInput.query) {
+    if (!graphQLInput.query) {
       return response
         .status(400)
         .json({ message: 'Query is missing, you must pass a valid GraphQL query' });
@@ -88,11 +88,7 @@ export const createGraphQLRoutes = (
           entityName === 'variables' && isEntityDescriptor(valueOrDescriptor);
         if (isVariablesPlain) {
           // ✅ important: getGraphQLInput returns empty object if variables not sent or invalid, so count {} as undefined
-          return resolveEntityValues(
-            checkMode,
-            Object.keys(graphQLInput.variables).length ? graphQLInput.variables : undefined,
-            descriptorValue
-          );
+          return resolveEntityValues(checkMode, graphQLInput.variables, descriptorValue);
         }
 
         const mappedEntityDescriptors = Object.entries(valueOrDescriptor) as [

--- a/src/core/graphql/createGraphQLRoutes/createGraphQLRoutes.ts
+++ b/src/core/graphql/createGraphQLRoutes/createGraphQLRoutes.ts
@@ -43,24 +43,29 @@ export const createGraphQLRoutes = (
         .status(400)
         .json({ message: 'Query is invalid, you must use a valid GraphQL query' });
     }
-    if (!query.operationName) {
-      return response.status(400).json({
-        message: `You should to specify operationName for ${request.method}:${request.baseUrl}${request.path}`
-      });
-    }
 
     const matchedRequestConfig = preparedGraphQLRequestConfig.find((requestConfig) => {
-      if (requestConfig.operationName instanceof RegExp) {
-        return (
-          new RegExp(requestConfig.operationName).test(query.operationName!) &&
-          requestConfig.operationType === query.operationType
-        );
+      if (requestConfig.operationType !== query.operationType) {
+        return false;
       }
 
-      return (
-        requestConfig.operationName === query.operationName &&
-        requestConfig.operationType === query.operationType
-      );
+      if ('query' in requestConfig && requestConfig.query !== graphQLInput.query) {
+        return false;
+      }
+
+      if ('operationName' in requestConfig) {
+        if (!query.operationName) {
+          return false;
+        }
+
+        if (requestConfig.operationName instanceof RegExp) {
+          return new RegExp(requestConfig.operationName).test(query.operationName);
+        }
+
+        return requestConfig.operationName === query.operationName;
+      }
+
+      return true;
     });
 
     if (!matchedRequestConfig) {

--- a/src/core/graphql/createGraphQLRoutes/createGraphQLRoutes.ts
+++ b/src/core/graphql/createGraphQLRoutes/createGraphQLRoutes.ts
@@ -43,16 +43,16 @@ export const createGraphQLRoutes = (
         .status(400)
         .json({ message: 'Query is invalid, you must use a valid GraphQL query' });
     }
-    if (!query.operationName || !query.operationType) {
+    if (!query.operationName) {
       return response.status(400).json({
-        message: `You should to specify operationName and operationType for ${request.method}:${request.baseUrl}${request.path}`
+        message: `You should to specify operationName for ${request.method}:${request.baseUrl}${request.path}`
       });
     }
 
     const matchedRequestConfig = preparedGraphQLRequestConfig.find((requestConfig) => {
       if (requestConfig.operationName instanceof RegExp) {
         return (
-          new RegExp(requestConfig.operationName).test(query.operationName) &&
+          new RegExp(requestConfig.operationName).test(query.operationName!) &&
           requestConfig.operationType === query.operationType
         );
       }
@@ -93,8 +93,9 @@ export const createGraphQLRoutes = (
         return recordEntries.every(([entityKey, entityValue]) => {
           const { checkMode, value: descriptorValue } = convertToEntityDescriptor(entityValue);
           const flattenEntity = flatten<any, any>(
-            entityName === 'variables' ? graphQLInput.variables : request[entityName]
+            entityName === 'variables' ? graphQLInput.variables ?? {} : request[entityName]
           );
+
           // ✅ important: transform header keys to lower case because browsers send headers in lowercase
           return resolveEntityValues(
             checkMode,

--- a/src/core/graphql/createGraphQLRoutes/createGraphQLRoutes.ts
+++ b/src/core/graphql/createGraphQLRoutes/createGraphQLRoutes.ts
@@ -86,16 +86,16 @@ export const createGraphQLRoutes = (
           convertToEntityDescriptor(entityDescriptorOrValue);
 
         // ✅ important: check whole variables as plain value strictly if descriptor used for variables
-        const isEntityVariablesByDescriptor =
+        const isEntityVariablesByTopLevelDescriptor =
           entityName === 'variables' && isEntityDescriptor(entityDescriptorOrValue);
-        if (isEntityVariablesByDescriptor) {
+        if (isEntityVariablesByTopLevelDescriptor) {
           return resolveEntityValues(checkMode, graphQLInput.variables, entityDescriptorValue);
         }
 
-        const recordEntries = Object.entries(entityDescriptorOrValue) as Entries<
+        const recordOrArrayEntries = Object.entries(entityDescriptorOrValue) as Entries<
           Exclude<GraphQLEntityDescriptorOrValue, GraphQLTopLevelPlainEntityDescriptor>
         >;
-        return recordEntries.every(([entityKey, entityValue]) => {
+        return recordOrArrayEntries.every(([entityKey, entityValue]) => {
           const { checkMode, value: descriptorValue } = convertToEntityDescriptor(entityValue);
           const flattenEntity = flatten<any, any>(
             entityName === 'variables' ? graphQLInput.variables ?? {} : request[entityName]
@@ -104,7 +104,9 @@ export const createGraphQLRoutes = (
           // ✅ important: transform header keys to lower case because browsers send headers in lowercase
           return resolveEntityValues(
             checkMode,
-            flattenEntity[entityName === 'headers' ? entityKey.toLowerCase() : entityKey],
+            flattenEntity[
+              entityName === 'headers' ? (entityKey as string).toLowerCase() : entityKey
+            ],
             descriptorValue
           );
         });

--- a/src/core/middlewares/corsMiddleware/corsMiddleware.test.ts
+++ b/src/core/middlewares/corsMiddleware/corsMiddleware.test.ts
@@ -28,7 +28,7 @@ describe('corsMiddleware', () => {
     });
   });
 
-  test(`Should set default cors for request if does not set custom cors settings`, async () => {
+  test('Should set default cors for request if does not set custom cors settings', async () => {
     const server = express();
     const cors: Cors = {
       origin: testOrigin
@@ -80,7 +80,7 @@ describe('corsMiddleware', () => {
       });
     });
 
-    test(`Should not set cors for request if origin does not match`, async () => {
+    test('Should not set cors for request if origin does not match', async () => {
       const server = express();
       const cors: Cors = {
         origin: unsuitableOrigin

--- a/src/core/middlewares/noCorsMiddleware/noCorsMiddleware.test.ts
+++ b/src/core/middlewares/noCorsMiddleware/noCorsMiddleware.test.ts
@@ -27,7 +27,7 @@ describe('noCorsMiddleware', () => {
     expect(response.statusCode).toBe(204);
   });
 
-  test(`Should set no cors settings for request`, async () => {
+  test('Should set no cors settings for request', async () => {
     const server = express();
 
     noCorsMiddleware(server);

--- a/src/core/middlewares/notFoundMiddleware/helpers/getGraphqlUrlSuggestions/getGraphqlUrlSuggestions.test.ts
+++ b/src/core/middlewares/notFoundMiddleware/helpers/getGraphqlUrlSuggestions/getGraphqlUrlSuggestions.test.ts
@@ -9,7 +9,7 @@ describe('getGraphqlUrlSuggestions', () => {
     ];
     expect(
       getGraphqlUrlSuggestions({
-        url: new URL(`http://localhost:31299/?query=query Getdevoper { developers }}`),
+        url: new URL('http://localhost:31299/?query=query Getdevoper { developers }}'),
         requestConfigs
       })
     ).toEqual([
@@ -19,7 +19,7 @@ describe('getGraphqlUrlSuggestions', () => {
 
     expect(
       getGraphqlUrlSuggestions({
-        url: new URL(`http://localhost:31299/?query=query devel { developers }}`),
+        url: new URL('http://localhost:31299/?query=query devel { developers }}'),
         requestConfigs
       })
     ).toEqual([]);

--- a/src/core/middlewares/notFoundMiddleware/notFoundMiddleware.ts
+++ b/src/core/middlewares/notFoundMiddleware/notFoundMiddleware.ts
@@ -22,12 +22,12 @@ export const notFoundMiddleware = (
 
   const graphqlRequestConfigs =
     graphql?.configs
-      .filter(({ operationName }) => !(operationName instanceof RegExp))
+      .filter((request) => 'operationName' in request && !(request.operationName instanceof RegExp))
       .map((request) => ({
         operationType: request.operationType,
         operationName: `${serverBaseUrl ?? ''}${graphql?.baseUrl ?? ''} ${
-          request.operationName
-        }` as string
+          (request as any).operationName
+        }`
       })) ?? [];
 
   server.use((request, response) => {

--- a/src/core/middlewares/notFoundMiddleware/notFoundMiddleware.ts
+++ b/src/core/middlewares/notFoundMiddleware/notFoundMiddleware.ts
@@ -1,7 +1,11 @@
 import type { Express } from 'express';
 
 import { parseGraphQLRequest } from '@/utils/helpers';
-import type { MockServerConfig, RestPathString } from '@/utils/types';
+import type {
+  MockServerConfig,
+  OperationNameGraphQLRequestConfig,
+  RestPathString
+} from '@/utils/types';
 
 import { getGraphqlUrlSuggestions, getRestUrlSuggestions } from './helpers';
 import type { RestRequestSuggestionConfigs, GraphqlRequestSuggestionConfigs } from './helpers';
@@ -26,7 +30,7 @@ export const notFoundMiddleware = (
       .map((request) => ({
         operationType: request.operationType,
         operationName: `${serverBaseUrl ?? ''}${graphql?.baseUrl ?? ''} ${
-          (request as any).operationName
+          (request as OperationNameGraphQLRequestConfig).operationName
         }`
       })) ?? [];
 

--- a/src/core/rest/createRestRoutes/createRestRoutes.test.ts
+++ b/src/core/rest/createRestRoutes/createRestRoutes.test.ts
@@ -1,7 +1,6 @@
 import express from 'express';
 import request from 'supertest';
 
-import { cookieParseMiddleware } from '@/core/middlewares';
 import { urlJoin } from '@/utils/helpers';
 import type { MockServerConfig, RestConfig } from '@/utils/types';
 
@@ -14,7 +13,6 @@ describe('createRestRoutes', () => {
     }
   ) => {
     const server = express();
-    cookieParseMiddleware(server);
 
     const routerBase = express.Router();
     const routerWithRoutes = createRestRoutes(

--- a/src/core/rest/createRestRoutes/createRestRoutes.test.ts
+++ b/src/core/rest/createRestRoutes/createRestRoutes.test.ts
@@ -144,6 +144,36 @@ describe('createRestRoutes', () => {
     });
   });
 
+  describe('createRestRoutes: top level array body', () => {
+    test('Should iterate over top level array body and compare with each element', async () => {
+      const server = createServer({
+        rest: {
+          configs: [
+            {
+              path: '/users',
+              method: 'post',
+              routes: [
+                {
+                  entities: {
+                    body: [{ key1: 'value1' }, ['value1', 'value2']]
+                  },
+                  data: { name: 'John', surname: 'Doe' }
+                }
+              ]
+            }
+          ]
+        }
+      });
+
+      const successResponse = await request(server).post('/users').send(['value1', 'value2']);
+      expect(successResponse.statusCode).toBe(200);
+      expect(successResponse.body).toStrictEqual({ name: 'John', surname: 'Doe' });
+
+      const notFoundResponse = await request(server).post('/users');
+      expect(notFoundResponse.statusCode).toBe(404);
+    });
+  });
+
   describe('createRestRoutes: descriptors', () => {
     test('Should strictly compare plain array body if top level descriptor used', async () => {
       const server = createServer({

--- a/src/core/rest/createRestRoutes/createRestRoutes.ts
+++ b/src/core/rest/createRestRoutes/createRestRoutes.ts
@@ -76,9 +76,7 @@ export const createRestRoutes = (
               // ✅ important: transform header keys to lower case because browsers send headers in lowercase
               return resolveEntityValues(
                 checkMode,
-                flattenEntity[
-                  entityName === 'headers' ? (entityKey as string).toLowerCase() : entityKey
-                ],
+                flattenEntity[entityName === 'headers' ? entityKey.toLowerCase() : entityKey],
                 descriptorValue
               );
             });

--- a/src/utils/helpers/entities/isEntityDescriptor/isEntityDescriptor.ts
+++ b/src/utils/helpers/entities/isEntityDescriptor/isEntityDescriptor.ts
@@ -1,3 +1,6 @@
+import type { EntityDescriptor } from '@/utils/types';
+
 import { isPlainObject } from '../../isPlainObject/isPlainObject';
 
-export const isEntityDescriptor = (value: any) => isPlainObject(value) && 'checkMode' in value;
+export const isEntityDescriptor = (value: any): value is EntityDescriptor =>
+  isPlainObject(value) && 'checkMode' in value;

--- a/src/utils/helpers/graphql/getGraphQLInput/getGraphQLInput.test.ts
+++ b/src/utils/helpers/graphql/getGraphQLInput/getGraphQLInput.test.ts
@@ -3,12 +3,29 @@ import type { Request } from 'express';
 import { getGraphQLInput } from './getGraphQLInput';
 
 describe('getGraphQLInput', () => {
-  test('Should get correct graphQL input from GET request', () => {
+  test('Should get correct graphQL input from GET request (with object variables)', () => {
     const mockRequest = {
       method: 'GET',
       query: {
         query: 'query GetCharacters { characters { name } }',
-        variables: '{"limit": 10}'
+        variables: { limit: 10 }
+      }
+    } as unknown as Request;
+
+    const graphQLInput = getGraphQLInput(mockRequest);
+
+    expect(graphQLInput).toStrictEqual({
+      query: 'query GetCharacters { characters { name } }',
+      variables: { limit: 10 }
+    });
+  });
+
+  test('Should get correct graphQL input from GET request (with string variables)', () => {
+    const mockRequest = {
+      method: 'GET',
+      query: {
+        query: 'query GetCharacters { characters { name } }',
+        variables: '{ "limit": 10 }'
       }
     } as unknown as Request;
 

--- a/src/utils/helpers/graphql/getGraphQLInput/getGraphQLInput.test.ts
+++ b/src/utils/helpers/graphql/getGraphQLInput/getGraphQLInput.test.ts
@@ -3,11 +3,11 @@ import type { Request } from 'express';
 import { getGraphQLInput } from './getGraphQLInput';
 
 describe('getGraphQLInput', () => {
-  test('Should get right graphQL input from GET request', () => {
+  test('Should get correct graphQL input from GET request', () => {
     const mockRequest = {
       method: 'GET',
       query: {
-        query: `query GetCharacters { characters { name } }`,
+        query: 'query GetCharacters { characters { name } }',
         variables: '{"limit": 10}'
       }
     } as unknown as Request;
@@ -20,11 +20,11 @@ describe('getGraphQLInput', () => {
     });
   });
 
-  test('Should get right graphQL input from GET request with empty variables', () => {
+  test('Should get correct graphQL input from GET request with empty variables', () => {
     const mockRequest = {
       method: 'GET',
       query: {
-        query: `query GetCharacters { characters { name } }`
+        query: 'query GetCharacters { characters { name } }'
       }
     } as unknown as Request;
 
@@ -32,15 +32,29 @@ describe('getGraphQLInput', () => {
 
     expect(graphQLInput).toStrictEqual({
       query: 'query GetCharacters { characters { name } }',
-      variables: {}
+      variables: undefined
     });
   });
 
-  test('Should get right graphQL input from POST request', () => {
+  test('Should get correct graphQL input from GET request with empty query and variables', () => {
+    const mockRequest = {
+      method: 'GET',
+      query: {}
+    } as unknown as Request;
+
+    const graphQLInput = getGraphQLInput(mockRequest);
+
+    expect(graphQLInput).toStrictEqual({
+      query: undefined,
+      variables: undefined
+    });
+  });
+
+  test('Should get correct graphQL input from POST request', () => {
     const mockRequest = {
       method: 'POST',
       body: {
-        query: `query GetCharacters { characters { name } }`,
+        query: 'query GetCharacters { characters { name } }',
         variables: { limit: 10 }
       }
     } as unknown as Request;
@@ -53,11 +67,11 @@ describe('getGraphQLInput', () => {
     });
   });
 
-  test('Should get right graphQL input from POST with empty variables', () => {
+  test('Should get correct graphQL input from POST with empty variables', () => {
     const mockRequest = {
       method: 'POST',
       body: {
-        query: `query GetCharacters { characters { name } }`
+        query: 'query GetCharacters { characters { name } }'
       }
     } as unknown as Request;
 
@@ -65,31 +79,45 @@ describe('getGraphQLInput', () => {
 
     expect(graphQLInput).toStrictEqual({
       query: 'query GetCharacters { characters { name } }',
-      variables: {}
+      variables: undefined
     });
   });
 
-  test('Should get error if request is not GET or POST', () => {
+  test('Should get correct graphQL input from POST with empty query and variables', () => {
+    const mockRequest = {
+      method: 'POST',
+      body: {}
+    } as unknown as Request;
+
+    const graphQLInput = getGraphQLInput(mockRequest);
+
+    expect(graphQLInput).toStrictEqual({
+      query: undefined,
+      variables: undefined
+    });
+  });
+
+  test('Should throw error if request method is not GET or POST', () => {
     const deleteMockRequest = {
       method: 'DELETE',
       query: {
-        query: `query GetCharacters { characters { name } }`
+        query: 'query GetCharacters { characters { name } }'
       }
     } as unknown as Request;
 
     expect(() => getGraphQLInput(deleteMockRequest)).toThrow(
-      'Not allowed request method for graphql request'
+      'Not allowed request method DELETE for graphql request'
     );
 
     const putMockRequest = {
       method: 'PUT',
       body: {
-        query: `query GetCharacters { characters { name } }`
+        query: 'query GetCharacters { characters { name } }'
       }
     } as unknown as Request;
 
     expect(() => getGraphQLInput(putMockRequest)).toThrow(
-      'Not allowed request method for graphql request'
+      'Not allowed request method PUT for graphql request'
     );
   });
 });

--- a/src/utils/helpers/graphql/getGraphQLInput/getGraphQLInput.ts
+++ b/src/utils/helpers/graphql/getGraphQLInput/getGraphQLInput.ts
@@ -1,25 +1,26 @@
 import type { Request } from 'express';
 
-import type { GraphQLInput } from '@/utils/types';
+import type { PlainObject } from '@/utils/types';
 
-export const getGraphQLInput = (request: Request): GraphQLInput => {
+interface GetGraphQLInputResult {
+  query: string | undefined;
+  variables: PlainObject | undefined;
+}
+
+export const getGraphQLInput = (request: Request): GetGraphQLInputResult => {
   if (request.method === 'GET') {
     const { query, variables } = request.query;
 
     return {
       query: query?.toString(),
-      variables: JSON.parse((variables as string) ?? '{}')
+      variables: variables && JSON.parse(variables as string)
     };
   }
 
   if (request.method === 'POST') {
     const { query, variables } = request.body;
-
-    return {
-      query,
-      variables: variables ?? {}
-    };
+    return { query, variables };
   }
 
-  throw new Error('Not allowed request method for graphql request');
+  throw new Error(`Not allowed request method ${request.method} for graphql request`);
 };

--- a/src/utils/helpers/graphql/getGraphQLInput/getGraphQLInput.ts
+++ b/src/utils/helpers/graphql/getGraphQLInput/getGraphQLInput.ts
@@ -11,9 +11,11 @@ export const getGraphQLInput = (request: Request): GetGraphQLInputResult => {
   if (request.method === 'GET') {
     const { query, variables } = request.query;
 
+    // ✅ important:
+    // if 'variables' was sent as encoded uri component then it already decoded into object and we do not need to use JSON.parse
     return {
       query: query?.toString(),
-      variables: variables && JSON.parse(variables as string)
+      variables: typeof variables === 'string' ? JSON.parse(variables as string) : variables
     };
   }
 

--- a/src/utils/helpers/graphql/parseQuery/parseQuery.test.ts
+++ b/src/utils/helpers/graphql/parseQuery/parseQuery.test.ts
@@ -26,7 +26,7 @@ describe('parseQuery', () => {
 
     expect(parsedQuery).toStrictEqual({
       operationType: 'query',
-      operationName: ''
+      operationName: undefined
     });
   });
 });

--- a/src/utils/helpers/graphql/parseQuery/parseQuery.ts
+++ b/src/utils/helpers/graphql/parseQuery/parseQuery.ts
@@ -3,7 +3,7 @@ import { parse } from 'graphql';
 
 interface ParseDocumentNodeResult {
   operationType: OperationTypeNode;
-  operationName: string;
+  operationName: string | undefined;
 }
 
 const parseDocumentNode = (node: DocumentNode): ParseDocumentNodeResult => {
@@ -13,7 +13,7 @@ const parseDocumentNode = (node: DocumentNode): ParseDocumentNodeResult => {
 
   return {
     operationType: operationDefinition.operation,
-    operationName: operationDefinition.name?.value ?? ''
+    operationName: operationDefinition.name?.value ?? undefined
   };
 };
 

--- a/src/utils/types/graphql.ts
+++ b/src/utils/types/graphql.ts
@@ -42,7 +42,7 @@ export type GraphQLTopLevelPlainEntityDescriptor<Check extends CheckMode = Check
       }
     : never;
 
-type GraphQLNestedLevelPlainEntityDescriptor<Check extends CheckMode = CheckMode> =
+type GraphQLPropertyLevelPlainEntityDescriptor<Check extends CheckMode = CheckMode> =
   Check extends 'function'
     ? {
         checkMode: Check;
@@ -89,7 +89,7 @@ export type GraphQLEntityDescriptorOrValue<
       | GraphQLTopLevelPlainEntityDescriptor
       | Record<
           string,
-          GraphQLNestedLevelPlainEntityDescriptor | GraphQLEntityValueOrValues<EntityName>
+          GraphQLPropertyLevelPlainEntityDescriptor | GraphQLEntityValueOrValues<EntityName>
         >
   : Record<string, GraphQLMappedEntityDescriptor | GraphQLEntityValueOrValues<EntityName>>;
 

--- a/src/utils/types/graphql.ts
+++ b/src/utils/types/graphql.ts
@@ -116,9 +116,18 @@ export interface GraphQLRouteConfig {
   interceptors?: Pick<Interceptors, 'response'>;
 }
 
-export interface GraphQLRequestConfig {
+interface GraphQLRequestConfigBase {
   operationType: GraphQLOperationType;
-  operationName: GraphQLOperationName;
   routes: GraphQLRouteConfig[];
   interceptors?: Interceptors;
 }
+
+interface OperationNameGraphQLRequestConfig extends GraphQLRequestConfigBase {
+  operationName: GraphQLOperationName;
+}
+
+interface QueryGraphQLRequestConfig extends GraphQLRequestConfigBase {
+  query: string;
+}
+
+export type GraphQLRequestConfig = OperationNameGraphQLRequestConfig | QueryGraphQLRequestConfig;

--- a/src/utils/types/graphql.ts
+++ b/src/utils/types/graphql.ts
@@ -118,7 +118,7 @@ interface BaseGraphQLRequestConfig {
   interceptors?: Interceptors;
 }
 
-interface OperationNameGraphQLRequestConfig extends BaseGraphQLRequestConfig {
+export interface OperationNameGraphQLRequestConfig extends BaseGraphQLRequestConfig {
   operationName: GraphQLOperationName;
 }
 

--- a/src/utils/types/graphql.ts
+++ b/src/utils/types/graphql.ts
@@ -12,17 +12,9 @@ import type { NestedObjectOrArray } from './utils';
 import type { Data } from './values';
 
 export type GraphQLEntityName = 'headers' | 'cookies' | 'query' | 'variables';
-type GraphQLPlainEntityName = Extract<GraphQLEntityName, 'variables'>;
-type GraphQLMappedEntityName = Exclude<GraphQLEntityName, 'variables'>;
 
 type GraphQLPlainEntityValue = string | number | boolean | null;
 type GraphQLMappedEntityValue = string | number | boolean;
-
-type GraphQLEntityValue<EntityName extends GraphQLEntityName> =
-  EntityName extends GraphQLPlainEntityName ? GraphQLPlainEntityValue : GraphQLMappedEntityValue;
-type GraphQLEntityValueOrValues<EntityName extends GraphQLEntityName> =
-  | GraphQLEntityValue<EntityName>
-  | GraphQLEntityValue<EntityName>[];
 
 export type GraphQLTopLevelPlainEntityDescriptor<Check extends CheckMode = CheckMode> =
   Check extends 'function'
@@ -79,7 +71,7 @@ type GraphQLMappedEntityDescriptor<Check extends CheckMode = CheckMode> = Check 
   : Check extends CompareWithDescriptorValueCheckMode
   ? {
       checkMode: Check;
-      value: GraphQLEntityValueOrValues<GraphQLMappedEntityName>;
+      value: GraphQLMappedEntityValue | GraphQLMappedEntityValue[];
     }
   : Check extends CheckActualValueCheckMode
   ? {
@@ -90,12 +82,15 @@ type GraphQLMappedEntityDescriptor<Check extends CheckMode = CheckMode> = Check 
 
 export type GraphQLEntityDescriptorOrValue<
   EntityName extends GraphQLEntityName = GraphQLEntityName
-> = EntityName extends GraphQLPlainEntityName
+> = EntityName extends 'variables'
   ?
       | GraphQLTopLevelPlainEntityDescriptor
       | Record<string, GraphQLPropertyLevelPlainEntityDescriptor>
       | NestedObjectOrArray<GraphQLPlainEntityValue>
-  : Record<string, GraphQLMappedEntityDescriptor | GraphQLEntityValueOrValues<EntityName>>;
+  : Record<
+      string,
+      GraphQLMappedEntityDescriptor | GraphQLMappedEntityValue | GraphQLMappedEntityValue[]
+    >;
 
 export type GraphQLOperationType = 'query' | 'mutation';
 export type GraphQLOperationName = string | RegExp;

--- a/src/utils/types/graphql.ts
+++ b/src/utils/types/graphql.ts
@@ -8,7 +8,7 @@ import type {
   CompareWithDescriptorValueCheckMode
 } from './checkModes';
 import type { Interceptors } from './interceptors';
-import type { NestedObject } from './utils';
+import type { NestedObjectOrArray } from './utils';
 import type { Data, Primitive } from './values';
 
 export type GraphQLEntityName = 'headers' | 'cookies' | 'query' | 'variables';
@@ -20,7 +20,7 @@ type GraphQLMappedEntityValue = string | number | boolean;
 
 type GraphQLEntityValue<EntityName extends GraphQLEntityName> =
   EntityName extends GraphQLPlainEntityName ? GraphQLPlainEntityValue : GraphQLMappedEntityValue;
-export type GraphQLEntityValueOrValues<EntityName extends GraphQLEntityName = GraphQLEntityName> =
+type GraphQLEntityValueOrValues<EntityName extends GraphQLEntityName> =
   | GraphQLEntityValue<EntityName>
   | GraphQLEntityValue<EntityName>[];
 
@@ -28,12 +28,15 @@ export type GraphQLTopLevelPlainEntityDescriptor<Check extends CheckMode = Check
   Check extends 'function'
     ? {
         checkMode: Check;
-        value: (actualValue: NestedObject<Primitive>, checkFunction: CheckFunction) => boolean;
+        value: (
+          actualValue: NestedObjectOrArray<GraphQLPlainEntityValue>,
+          checkFunction: CheckFunction
+        ) => boolean;
       }
     : Check extends CompareWithDescriptorAnyValueCheckMode
     ? {
         checkMode: Check;
-        value: Record<string, GraphQLPlainEntityValue> | Record<string, GraphQLPlainEntityValue>[];
+        value: NestedObjectOrArray<GraphQLPlainEntityValue>;
       }
     : Check extends CheckActualValueCheckMode
     ? {
@@ -46,12 +49,15 @@ type GraphQLPropertyLevelPlainEntityDescriptor<Check extends CheckMode = CheckMo
   Check extends 'function'
     ? {
         checkMode: Check;
-        value: (actualValue: GraphQLPlainEntityValue, checkFunction: CheckFunction) => boolean;
+        value: (
+          actualValue: GraphQLPlainEntityValue | NestedObjectOrArray<GraphQLPlainEntityValue>,
+          checkFunction: CheckFunction
+        ) => boolean;
       }
     : Check extends CompareWithDescriptorAnyValueCheckMode
     ? {
         checkMode: Check;
-        value: GraphQLEntityValueOrValues<GraphQLPlainEntityName>;
+        value: GraphQLPlainEntityValue | NestedObjectOrArray<GraphQLPlainEntityValue>;
       }
     : Check extends CheckActualValueCheckMode
     ? {
@@ -89,7 +95,9 @@ export type GraphQLEntityDescriptorOrValue<
       | GraphQLTopLevelPlainEntityDescriptor
       | Record<
           string,
-          GraphQLPropertyLevelPlainEntityDescriptor | GraphQLEntityValueOrValues<EntityName>
+          | GraphQLPropertyLevelPlainEntityDescriptor
+          | GraphQLEntityValue<EntityName>
+          | NestedObjectOrArray<GraphQLEntityValue<EntityName>>
         >
   : Record<string, GraphQLMappedEntityDescriptor | GraphQLEntityValueOrValues<EntityName>>;
 

--- a/src/utils/types/graphql.ts
+++ b/src/utils/types/graphql.ts
@@ -9,13 +9,13 @@ import type {
 } from './checkModes';
 import type { Interceptors } from './interceptors';
 import type { NestedObjectOrArray } from './utils';
-import type { Data, Primitive } from './values';
+import type { Data } from './values';
 
 export type GraphQLEntityName = 'headers' | 'cookies' | 'query' | 'variables';
 type GraphQLPlainEntityName = Extract<GraphQLEntityName, 'variables'>;
 type GraphQLMappedEntityName = Exclude<GraphQLEntityName, 'variables'>;
 
-type GraphQLPlainEntityValue = Primitive;
+type GraphQLPlainEntityValue = string | number | boolean | null;
 type GraphQLMappedEntityValue = string | number | boolean;
 
 type GraphQLEntityValue<EntityName extends GraphQLEntityName> =
@@ -93,12 +93,8 @@ export type GraphQLEntityDescriptorOrValue<
 > = EntityName extends GraphQLPlainEntityName
   ?
       | GraphQLTopLevelPlainEntityDescriptor
-      | Record<
-          string,
-          | GraphQLPropertyLevelPlainEntityDescriptor
-          | GraphQLEntityValue<EntityName>
-          | NestedObjectOrArray<GraphQLEntityValue<EntityName>>
-        >
+      | Record<string, GraphQLPropertyLevelPlainEntityDescriptor>
+      | NestedObjectOrArray<GraphQLPlainEntityValue>
   : Record<string, GraphQLMappedEntityDescriptor | GraphQLEntityValueOrValues<EntityName>>;
 
 export type GraphQLOperationType = 'query' | 'mutation';
@@ -111,22 +107,22 @@ export type GraphQLEntitiesByEntityName = {
   [EntityName in GraphQLEntityName]?: GraphQLEntityDescriptorOrValue<EntityName>;
 };
 export interface GraphQLRouteConfig {
-  entities?: GraphQLEntitiesByEntityName;
   data: ((request: Request, entities: GraphQLEntitiesByEntityName) => Data | Promise<Data>) | Data;
+  entities?: GraphQLEntitiesByEntityName;
   interceptors?: Pick<Interceptors, 'response'>;
 }
 
-interface GraphQLRequestConfigBase {
+interface BaseGraphQLRequestConfig {
   operationType: GraphQLOperationType;
   routes: GraphQLRouteConfig[];
   interceptors?: Interceptors;
 }
 
-interface OperationNameGraphQLRequestConfig extends GraphQLRequestConfigBase {
+interface OperationNameGraphQLRequestConfig extends BaseGraphQLRequestConfig {
   operationName: GraphQLOperationName;
 }
 
-interface QueryGraphQLRequestConfig extends GraphQLRequestConfigBase {
+interface QueryGraphQLRequestConfig extends BaseGraphQLRequestConfig {
   query: string;
 }
 

--- a/src/utils/types/index.ts
+++ b/src/utils/types/index.ts
@@ -4,4 +4,5 @@ export * from './graphql';
 export * from './interceptors';
 export * from './rest';
 export * from './server';
+export * from './utils';
 export * from './values';

--- a/src/utils/types/rest.ts
+++ b/src/utils/types/rest.ts
@@ -13,18 +13,9 @@ import type { Data } from './values';
 
 export type RestMethod = 'get' | 'post' | 'delete' | 'put' | 'patch' | 'options';
 export type RestEntityName = 'headers' | 'cookies' | 'query' | 'params' | 'body';
-type RestPlainEntityName = Extract<RestEntityName, 'body'>;
-type RestMappedEntityName = Exclude<RestEntityName, 'body'>;
 
 type RestPlainEntityValue = string | number | boolean | null;
 type RestMappedEntityValue = string | number | boolean;
-
-type RestEntityValue<EntityName extends RestEntityName> = EntityName extends RestPlainEntityName
-  ? RestPlainEntityValue
-  : RestMappedEntityValue;
-type RestEntityValueOrValues<EntityName extends RestEntityName> =
-  | RestEntityValue<EntityName>
-  | RestEntityValue<EntityName>[];
 
 export type RestTopLevelPlainEntityDescriptor<Check extends CheckMode = CheckMode> =
   Check extends 'function'
@@ -81,7 +72,7 @@ type RestMappedEntityDescriptor<Check extends CheckMode = CheckMode> = Check ext
   : Check extends CompareWithDescriptorValueCheckMode
   ? {
       checkMode: Check;
-      value: RestEntityValueOrValues<RestMappedEntityName>;
+      value: RestMappedEntityValue | RestMappedEntityValue[];
     }
   : Check extends CheckActualValueCheckMode
   ? {
@@ -91,17 +82,12 @@ type RestMappedEntityDescriptor<Check extends CheckMode = CheckMode> = Check ext
   : never;
 
 export type RestEntityDescriptorOrValue<EntityName extends RestEntityName = RestEntityName> =
-  EntityName extends RestPlainEntityName
+  EntityName extends 'body'
     ?
         | RestTopLevelPlainEntityDescriptor
+        | Record<string, RestPropertyLevelPlainEntityDescriptor>
         | NestedObjectOrArray<RestPlainEntityValue>
-        | Record<
-            string,
-            | RestPropertyLevelPlainEntityDescriptor
-            | RestPlainEntityValue
-            | NestedObjectOrArray<RestPlainEntityValue>
-          >
-    : Record<string, RestMappedEntityDescriptor | RestEntityValueOrValues<EntityName>>;
+    : Record<string, RestMappedEntityDescriptor | RestMappedEntityValue | RestMappedEntityValue[]>;
 
 export type RestEntityNamesByMethod = {
   [key in RestMethod]: key extends 'get' | 'delete' | 'options'

--- a/src/utils/types/rest.ts
+++ b/src/utils/types/rest.ts
@@ -1,7 +1,6 @@
 import type { Request } from 'express';
 
 import type {
-  CalculateByDescriptorValueCheckMode,
   CheckActualValueCheckMode,
   CheckFunction,
   CheckMode,
@@ -9,69 +8,72 @@ import type {
   CompareWithDescriptorValueCheckMode
 } from './checkModes';
 import type { Interceptors } from './interceptors';
-import type { Data, Primitive } from './values';
+import type { NestedObjectOrArray } from './utils';
+import type { Data } from './values';
 
 export type RestMethod = 'get' | 'post' | 'delete' | 'put' | 'patch' | 'options';
-
 export type RestEntityName = 'headers' | 'cookies' | 'query' | 'params' | 'body';
+type RestPlainEntityName = Extract<RestEntityName, 'body'>;
+type RestMappedEntityName = Exclude<RestEntityName, 'body'>;
 
-export type RestMappedEntityKey = string;
+type RestPlainEntityValue = string | number | boolean | null;
 type RestMappedEntityValue = string | number | boolean;
 
-type RestPlainEntityInnerValue = {
-  checkMode?: undefined;
-  call?: undefined;
-  dotAll?: undefined;
-  [key: string]: Primitive | RestPlainEntityInnerValue;
-};
-
-type RestPlainEntityValue =
-  // ✅ important:
-  // Omit `checkMode` key for fix types,
-  // Omit `call` key for exclude functions,
-  // Omit `dotAll` for exclude RegExp.
-  | {
-      checkMode?: undefined;
-      call?: undefined;
-      dotAll?: undefined;
-      [key: string]: RestPlainEntityInnerValue | Primitive | RestEntityDescriptor;
-    }
-  | (RestPlainEntityInnerValue | Primitive | RestEntityDescriptor)[];
-
-type RestEntityValue<EntityName = RestEntityName> = EntityName extends 'body'
+type RestEntityValue<EntityName extends RestEntityName> = EntityName extends RestPlainEntityName
   ? RestPlainEntityValue
   : RestMappedEntityValue;
-
-type RestEntityValueOrValues<EntityName = RestEntityName> =
+type RestEntityValueOrValues<EntityName extends RestEntityName> =
   | RestEntityValue<EntityName>
   | RestEntityValue<EntityName>[];
 
-type RestEntityDescriptor<
-  EntityName extends RestEntityName = RestEntityName,
-  Check extends CheckMode = CheckMode
-> = EntityName extends 'body'
-  ? Check extends Extract<CalculateByDescriptorValueCheckMode, 'function'>
+export type RestTopLevelPlainEntityDescriptor<Check extends CheckMode = CheckMode> =
+  Check extends 'function'
     ? {
         checkMode: Check;
-        value: (actualValue: any, checkFunction: CheckFunction) => boolean;
+        value: (
+          actualValue: NestedObjectOrArray<RestPlainEntityValue>,
+          checkFunction: CheckFunction
+        ) => boolean;
       }
     : Check extends CompareWithDescriptorAnyValueCheckMode
     ? {
         checkMode: Check;
-        value: RestEntityValueOrValues<EntityName>;
+        value: NestedObjectOrArray<RestPlainEntityValue>;
       }
     : Check extends CheckActualValueCheckMode
     ? {
         checkMode: Check;
-        value?: undefined;
+        value: never;
       }
-    : never
-  : Check extends Extract<CalculateByDescriptorValueCheckMode, 'function'>
+    : never;
+
+type RestPropertyLevelPlainEntityDescriptor<Check extends CheckMode = CheckMode> =
+  Check extends 'function'
+    ? {
+        checkMode: Check;
+        value: (
+          actualValue: RestPlainEntityValue | NestedObjectOrArray<RestPlainEntityValue>,
+          checkFunction: CheckFunction
+        ) => boolean;
+      }
+    : Check extends CompareWithDescriptorAnyValueCheckMode
+    ? {
+        checkMode: Check;
+        value: RestPlainEntityValue | NestedObjectOrArray<RestPlainEntityValue>;
+      }
+    : Check extends CheckActualValueCheckMode
+    ? {
+        checkMode: Check;
+        value: never;
+      }
+    : never;
+
+type RestMappedEntityDescriptor<Check extends CheckMode = CheckMode> = Check extends 'function'
   ? {
       checkMode: Check;
-      value: (actualValue: any, checkFunction: CheckFunction) => boolean;
+      value: (actualValue: RestMappedEntityValue, checkFunction: CheckFunction) => boolean;
     }
-  : Check extends Extract<CalculateByDescriptorValueCheckMode, 'regExp'>
+  : Check extends 'regExp'
   ? {
       checkMode: Check;
       value: RegExp | RegExp[];
@@ -79,47 +81,43 @@ type RestEntityDescriptor<
   : Check extends CompareWithDescriptorValueCheckMode
   ? {
       checkMode: Check;
-      value: RestEntityValueOrValues<EntityName>;
+      value: RestEntityValueOrValues<RestMappedEntityName>;
     }
   : Check extends CheckActualValueCheckMode
   ? {
       checkMode: Check;
-      value?: undefined;
+      value: never;
     }
   : never;
 
 export type RestEntityDescriptorOrValue<EntityName extends RestEntityName = RestEntityName> =
-  EntityName extends 'body'
-    ? RestEntityDescriptor<EntityName> | RestEntityValue<EntityName>
-    : Record<
-        RestMappedEntityKey,
-        RestEntityDescriptor<EntityName> | RestEntityValueOrValues<EntityName>
-      >;
+  EntityName extends RestPlainEntityName
+    ?
+        | RestTopLevelPlainEntityDescriptor
+        | NestedObjectOrArray<RestPlainEntityValue>
+        | Record<
+            string,
+            | RestPropertyLevelPlainEntityDescriptor
+            | RestPlainEntityValue
+            | NestedObjectOrArray<RestPlainEntityValue>
+          >
+    : Record<string, RestMappedEntityDescriptor | RestEntityValueOrValues<EntityName>>;
 
-export type RestEntityDescriptorOnly<EntityName extends RestEntityName = RestEntityName> =
-  EntityName extends 'body'
-    ? RestEntityDescriptor<EntityName>
-    : Record<RestMappedEntityKey, RestEntityDescriptor<EntityName>>;
-
-export interface RestEntityNamesByMethod {
-  get: Exclude<RestEntityName, 'body'>;
-  delete: Exclude<RestEntityName, 'body'>;
-  post: RestEntityName;
-  put: RestEntityName;
-  patch: RestEntityName;
-  options: Exclude<RestEntityName, 'body'>;
-}
-
-export type RestEntityByEntityName<Method extends RestMethod> = {
+export type RestEntityNamesByMethod = {
+  [key in RestMethod]: key extends 'get' | 'delete' | 'options'
+    ? Exclude<RestEntityName, 'body'>
+    : RestEntityName;
+};
+export type RestEntitiesByEntityName<Method extends RestMethod = RestMethod> = {
   [EntityName in RestEntityNamesByMethod[Method]]?: RestEntityDescriptorOrValue<EntityName>;
 };
 
 export interface RestRouteConfig<
   Method extends RestMethod,
-  Entities extends RestEntityByEntityName<Method> = RestEntityByEntityName<Method>
+  Entities extends RestEntitiesByEntityName<Method> = RestEntitiesByEntityName<Method>
 > {
-  entities?: Entities;
   data: ((request: Request, entities: Entities) => Data | Promise<Data>) | Data;
+  entities?: Entities;
   interceptors?: Pick<Interceptors, 'response'>;
 }
 

--- a/src/utils/types/utils.ts
+++ b/src/utils/types/utils.ts
@@ -1,7 +1,13 @@
 import type { PlainObject } from './values';
 
-export type ValueOf<T extends PlainObject> = T[keyof T];
-export type Entries<T extends PlainObject> = ValueOf<{ [K in keyof T]-?: [K, T[K]] }>[];
+export type ValueOf<T extends PlainObject | Array<any>> = T extends Array<any>
+  ? T[number]
+  : T[keyof T];
+
+export type Entries<T extends PlainObject | Array<any>> = ValueOf<{
+  [K in keyof T]-?: [K, T[K]];
+}>[];
+
 export type NestedObjectOrArray<T> =
   | { [key: string]: NestedObjectOrArray<T> | T }
   | Array<NestedObjectOrArray<T> | T>;

--- a/src/utils/types/utils.ts
+++ b/src/utils/types/utils.ts
@@ -1,0 +1,5 @@
+import type { PlainObject } from './values';
+
+export type ValueOf<T extends PlainObject> = T[keyof T];
+export type Entries<T extends PlainObject> = ValueOf<{ [K in keyof T]-?: [K, T[K]] }>[];
+export type NestedObject<T> = { [key: string]: NestedObject<T> | T };

--- a/src/utils/types/utils.ts
+++ b/src/utils/types/utils.ts
@@ -2,4 +2,6 @@ import type { PlainObject } from './values';
 
 export type ValueOf<T extends PlainObject> = T[keyof T];
 export type Entries<T extends PlainObject> = ValueOf<{ [K in keyof T]-?: [K, T[K]] }>[];
-export type NestedObject<T> = { [key: string]: NestedObject<T> | T };
+export type NestedObjectOrArray<T> =
+  | { [key: string]: NestedObjectOrArray<T> | T }
+  | Array<NestedObjectOrArray<T> | T>;

--- a/src/utils/types/values.ts
+++ b/src/utils/types/values.ts
@@ -1,5 +1,4 @@
 export type PlainObject = Record<string, any>;
-export type PlainFunction = (...args: any[]) => any;
 
 export type Primitive = boolean | number | bigint | string | null | undefined | symbol;
 


### PR DESCRIPTION
EDITED.

Подведу итоги PR-a.

1. Было добавлено новое поле **query** в graphql request config. Теперь пользователь может указать либо query, либо operationName, либо оба.
2. Исправлены ошибки типизации для конфигурации. Ошибки в основном связанные с descriptors.
3. Исправлены ошибки валидации для конфигурации. Ошибки в основном связанные с descriptors.
4. Тесты функций validateRoutes и createRoutes (и для rest, и для graphql) были сильно сокращены за счет параметризации.
5. Была переработана логика функции `isDescriptorValueValid` — добавлена обработка вложенных объектов/массивов.