### PR TITLE
#126 into release@3.3.0 👹 fix 'setCookie' function in response interceptors params

### DIFF
--- a/src/utils/helpers/interceptors/callRequestInterceptor/callRequestInterceptors.test.ts
+++ b/src/utils/helpers/interceptors/callRequestInterceptor/callRequestInterceptors.test.ts
@@ -1,13 +1,53 @@
 import type { Request } from 'express';
 
+import type { RequestInterceptor } from '@/utils/types';
+
 import { callRequestInterceptor } from './callRequestInterceptor';
 
-describe('callRequestInterceptors', () => {
+describe('callRequestInterceptors: order of calls', () => {
   test('Should call passed request interceptor', () => {
     const request = {} as Request;
     const interceptor = jest.fn();
 
     callRequestInterceptor({ request, interceptor });
     expect(interceptor.mock.calls.length).toBe(1);
+  });
+});
+
+describe('callRequestInterceptors: params functions', () => {
+  test('Should correctly get header from request.headers object when use getHeader param', () => {
+    const request = { headers: { name: 'value' } };
+    const getHeaderRequestInterceptor: RequestInterceptor = ({ getHeader }) => {
+      expect(getHeader('name')).toBe('value');
+    };
+
+    callRequestInterceptor({
+      request: request as unknown as Request,
+      interceptor: getHeaderRequestInterceptor
+    });
+  });
+
+  test('Should correctly get headers as request.headers object when use getHeaders param', () => {
+    const request = { headers: { name: 'value' } };
+    const getHeadersRequestInterceptor: RequestInterceptor = ({ getHeaders }) => {
+      expect(getHeaders()).toStrictEqual({ name: 'value' });
+    };
+
+    callRequestInterceptor({
+      request: request as unknown as Request,
+      interceptor: getHeadersRequestInterceptor
+    });
+  });
+
+  test('Should correctly get cookie from request.cookies object when use getCookie param', () => {
+    const request = { cookies: { name: 'value' } };
+    const getCookieRequestInterceptor: RequestInterceptor = ({ getCookie }) => {
+      expect(getCookie('name')).toBe('value');
+    };
+
+    callRequestInterceptor({
+      request: request as unknown as Request,
+      interceptor: getCookieRequestInterceptor
+    });
   });
 });

--- a/src/utils/helpers/interceptors/callResponseInterceptors/callResponseInterceptors.ts
+++ b/src/utils/helpers/interceptors/callResponseInterceptors/callResponseInterceptors.ts
@@ -21,26 +21,32 @@ export const callResponseInterceptors = async (params: CallResponseInterceptorsP
 
   const getHeader = (field: string) => response.getHeader(field);
   const getHeaders = () => response.getHeaders();
-
-  const getCookie = (name: string) => request.cookies[name];
+  const setHeader = (field: string, value?: string | string[]) => {
+    response.set(field, value);
+  };
+  const appendHeader = (field: string, value?: string | string[]) => {
+    response.append(field, value);
+  };
 
   const setStatusCode = (statusCode: number) => {
     response.statusCode = statusCode;
   };
 
-  const setHeader = (field: string, value?: string | string[]) => response.set(field, value);
-  const appendHeader = (field: string, value?: string[] | string) => response.append(field, value);
-
+  const getCookie = (name: string) => request.cookies[name];
   const setCookie = (name: string, value: string, options?: CookieOptions) => {
     if (options) {
       response.cookie(name, value, options);
+      return;
     }
     response.cookie(name, value);
   };
-  const clearCookie = (name: string, options?: CookieOptions) =>
+  const clearCookie = (name: string, options?: CookieOptions) => {
     response.clearCookie(name, options);
+  };
 
-  const attachment = (filename: string) => response.attachment(filename);
+  const attachment = (filename: string) => {
+    response.attachment(filename);
+  };
 
   const ResponseInterceptorParams: ResponseInterceptorParams = {
     request,


### PR DESCRIPTION
response method cookie called twice if you pass options into setCookie function (in response interceptor)