### PR TITLE
#184 into release@3.6.1 👹 sort rest request configs by path: parameterized paths have lower priority

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,6 +18,7 @@ module.exports = {
         '@typescript-eslint/naming-convention': 'off',
         'no-underscore-dangle': 'off',
         'no-restricted-syntax': 'off',
+        'no-continue': 'off',
         'promise/always-return': ['error', { ignoreLastCallback: true }],
         'arrow-body-style': ['error', 'as-needed']
       }

--- a/bin/helpers/getMostSpecificPathFromError.ts
+++ b/bin/helpers/getMostSpecificPathFromError.ts
@@ -10,7 +10,6 @@ export const getMostSpecificPathFromError = (error: z.ZodError): (string | numbe
           currentMostSpecificPath = unionErrorMostSpecificPath;
         }
       }
-      // eslint-disable-next-line no-continue
       continue;
     }
 
@@ -20,7 +19,6 @@ export const getMostSpecificPathFromError = (error: z.ZodError): (string | numbe
       if (issuePath.length > currentMostSpecificPath.length) {
         currentMostSpecificPath = issuePath;
       }
-      // eslint-disable-next-line no-continue
       continue;
     }
 

--- a/src/core/rest/createRestRoutes/helpers/prepareRestRequestConfigs/prepareRestRequestConfigs.test.ts
+++ b/src/core/rest/createRestRoutes/helpers/prepareRestRequestConfigs/prepareRestRequestConfigs.test.ts
@@ -3,6 +3,64 @@ import type { RestRequestConfig } from '@/utils/types';
 import { prepareRestRequestConfigs } from './prepareRestRequestConfigs';
 
 describe('prepareRestRequestConfigs', () => {
+  test('Should sort request configs only when same route segments is parameterized and not parameterized (not parameterized should be ahead)', () => {
+    const restRequestConfigs: RestRequestConfig[] = [
+      {
+        path: '/user',
+        method: 'get',
+        routes: []
+      },
+      {
+        path: /\/user/,
+        method: 'get',
+        routes: []
+      },
+      {
+        path: '/settings/:id2/:id3/:id4/:id5/',
+        method: 'get',
+        routes: []
+      },
+      {
+        path: '/users/:id2/:id3/4/:id5/',
+        method: 'get',
+        routes: []
+      },
+      {
+        path: '/users/:id2/3/:id4/:id5',
+        method: 'get',
+        routes: []
+      }
+    ];
+    const expectedRestRequestConfigs: RestRequestConfig[] = [
+      {
+        path: '/user',
+        method: 'get',
+        routes: []
+      },
+      {
+        path: /\/user/,
+        method: 'get',
+        routes: []
+      },
+      {
+        path: '/settings/:id2/:id3/:id4/:id5/',
+        method: 'get',
+        routes: []
+      },
+      {
+        path: '/users/:id2/3/:id4/:id5',
+        method: 'get',
+        routes: []
+      },
+      {
+        path: '/users/:id2/:id3/4/:id5/',
+        method: 'get',
+        routes: []
+      }
+    ];
+    expect(prepareRestRequestConfigs(restRequestConfigs)).toStrictEqual(expectedRestRequestConfigs);
+  });
+
   test('Should not sort routes if they do not contain entities', () => {
     const restRequestConfigs: RestRequestConfig[] = [
       {

--- a/src/core/rest/createRestRoutes/helpers/prepareRestRequestConfigs/prepareRestRequestConfigs.test.ts
+++ b/src/core/rest/createRestRoutes/helpers/prepareRestRequestConfigs/prepareRestRequestConfigs.test.ts
@@ -3,7 +3,7 @@ import type { RestRequestConfig } from '@/utils/types';
 import { prepareRestRequestConfigs } from './prepareRestRequestConfigs';
 
 describe('prepareRestRequestConfigs', () => {
-  test('Should sort request configs only when same route segments is parameterized and not parameterized (not parameterized should be ahead)', () => {
+  test('Should sort request configs only when equal position path parts is parameter and non-parameter (non-parameter should be ahead)', () => {
     const restRequestConfigs: RestRequestConfig[] = [
       {
         path: '/user',

--- a/src/core/rest/createRestRoutes/helpers/prepareRestRequestConfigs/prepareRestRequestConfigs.ts
+++ b/src/core/rest/createRestRoutes/helpers/prepareRestRequestConfigs/prepareRestRequestConfigs.ts
@@ -36,10 +36,8 @@ export const prepareRestRequestConfigs = (requestConfigs: RestRequestConfig[]) =
     if (first instanceof RegExp || second instanceof RegExp) return 0;
     if (!first.includes('/:') && !second.includes('/:')) return 0;
 
-    // ✅ important:
-    // remove trailing slashes because they can affect 'split' method result
-    const firstRouteSegments = first.replace(/\/$/, '').split('/');
-    const secondRouteSegments = second.replace(/\/$/, '').split('/');
+    const firstRouteSegments = first.split('/');
+    const secondRouteSegments = second.split('/');
 
     for (let i = 0; i < Math.min(firstRouteSegments.length, secondRouteSegments.length); i += 1) {
       const firstRouteSegment = firstRouteSegments[i];

--- a/src/core/rest/createRestRoutes/helpers/prepareRestRequestConfigs/prepareRestRequestConfigs.ts
+++ b/src/core/rest/createRestRoutes/helpers/prepareRestRequestConfigs/prepareRestRequestConfigs.ts
@@ -33,7 +33,7 @@ export const prepareRestRequestConfigs = (requestConfigs: RestRequestConfig[]) =
   const sortedByPathRequestConfigs = requestConfigs.sort(
     ({ path: firstPath }, { path: secondPath }) => {
       // ✅ important:
-      // do not compare RegExp paths and paths without parameters
+      // do not compare RegExp paths and non-parameterized paths
       if (firstPath instanceof RegExp || secondPath instanceof RegExp) return 0;
       if (!firstPath.includes('/:') && !secondPath.includes('/:')) return 0;
 
@@ -42,7 +42,7 @@ export const prepareRestRequestConfigs = (requestConfigs: RestRequestConfig[]) =
       const minimalPathPartsLength = Math.min(firstPathParts.length, secondPathParts.length);
 
       // ✅ important:
-      // need to find the leftmost parameterized/not-parameterized pair and give priority to not-parameterized one
+      // need to find the leftmost parameter/non-parameter pair and give priority to not-parameter one
       for (let i = 0; i < minimalPathPartsLength; i += 1) {
         const firstPathPart = firstPathParts[i];
         const secondPathPart = secondPathParts[i];

--- a/src/core/rest/createRestRoutes/helpers/prepareRestRequestConfigs/prepareRestRequestConfigs.ts
+++ b/src/core/rest/createRestRoutes/helpers/prepareRestRequestConfigs/prepareRestRequestConfigs.ts
@@ -42,7 +42,7 @@ export const prepareRestRequestConfigs = (requestConfigs: RestRequestConfig[]) =
       const minimalPathPartsLength = Math.min(firstPathParts.length, secondPathParts.length);
 
       // ✅ important:
-      // need to find the leftmost parameter/non-parameter pair and give priority to not-parameter one
+      // need to find the leftmost parameter/non-parameter pair and give priority to non-parameter one
       for (let i = 0; i < minimalPathPartsLength; i += 1) {
         const firstPathPart = firstPathParts[i];
         const secondPathPart = secondPathParts[i];


### PR DESCRIPTION
Let's say we have following rest config

```typescipt
[
  {
    path: '/users/:id/',
    method: 'get',
    routes: []
  },
  {
    path: '/users/1',
    method: 'get',
    routes: []
  },
]
```
I'll try to describe logic of my code.
1. First of all we do not interested of RegExp or not parameterized paths pairs
2. Split paths for getting route segments, i.e. we get two arrays
```typescipt
['users', ':id']
['users', '1']
```
> i skipped empty strings in array because of their no impact to context of my explanation.

3. From left to right iterate over arrays and compare strings. We need to find first pair where one element is parameterized (starts with `:`) and another one is not parameterized. Also, I also want to draw attention to the fact that we are skipped case where poth element of pair is not parameterized and not equal (because it means that handled URL's are different)
4. Give priority to path where route segment is not parameterized

### Questions and answers

> Why don't use sort in alphabetical order? 

Because numbers have lower char code than `:`, but `:` have lower char code than letters. It can be reason of this result after sort
```typescript
[
  {
    path: '/users/me/',
    method: 'get',
    routes: []
  },
  {
    path: '/users/:id/',
    method: 'get',
    routes: []
  },
  {
    path: '/users/1',
    method: 'get',
    routes: []
  },
]
```

> Why you find only first parameterized + not-parameterized pair of route segments?

Because when we find first of this kind of pairs and sort them then paths become non-intersecting. Following config is already sorted and all requests "splits": `/users/1/**` and `/users/:id1/**`. It doesn't matter what is rest of url after second route fragment
```typescript
[
 {
    path: '/users/1/:id2',
    method: 'get',
    routes: []
  },
  {
    path: '/users/:id1/2',
    method: 'get',
    routes: []
  }
]
```